### PR TITLE
Fix link preview colors in christmas dark mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "textodon",

--- a/src/ui/styles/main.css
+++ b/src/ui/styles/main.css
@@ -1106,6 +1106,12 @@ button.ghost {
     background: #171512;
   }
 
+  :root[data-theme="christmas"] .link-preview,
+  body[data-theme="christmas"] .link-preview {
+    border: 1px solid #3b2624;
+    background: #1a100f;
+  }
+
   .link-preview-body {
     color: #c4b6a6;
   }


### PR DESCRIPTION
## Summary
- fix christmas theme link preview card colors in dark mode
- align link preview background/border with christmas dark palette

## Testing
- not run