### PR TITLE
Persist timeline sections and separate compose account

### DIFF
--- a/src/ui/components/ComposeBox.tsx
+++ b/src/ui/components/ComposeBox.tsx
@@ -14,7 +14,8 @@ export const ComposeBox = ({
   onSubmit,
   replyingTo,
   onCancelReply,
-  mentionText
+  mentionText,
+  accountSelector
 }: {
   onSubmit: (params: {
     text: string;
@@ -25,6 +26,7 @@ export const ComposeBox = ({
   replyingTo: { id: string; summary: string } | null;
   onCancelReply: () => void;
   mentionText: string | null;
+  accountSelector?: React.ReactNode;
 }) => {
   const [text, setText] = useState("");
   const [visibility, setVisibility] = useState<Visibility>(() => {
@@ -182,6 +184,7 @@ export const ComposeBox = ({
 
   return (
     <section className="panel">
+      {accountSelector ? <div className="compose-account-select">{accountSelector}</div> : null}
       {replyingTo ? (
         <div className="replying">
           <span>답글 대상: {replyingTo.summary}</span>

--- a/src/ui/styles/main.css
+++ b/src/ui/styles/main.css
@@ -217,6 +217,7 @@ body {
   display: grid;
   grid-template-columns: minmax(260px, 320px) 1fr;
   gap: 24px;
+  align-items: start;
 }
 
 aside {
@@ -637,6 +638,49 @@ button.ghost {
 
 .timeline-header-actions > button {
   height: 48px;
+}
+
+.timeline-board {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.timeline-column {
+  flex: 0 0 440px;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: #fffdfa;
+  border: 1px solid #e2ddd5;
+  border-radius: 14px;
+  padding: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 12px 24px rgba(67, 57, 45, 0.06);
+}
+
+:root[data-theme="christmas"] .timeline-column {
+  background: #fff7f2;
+  border: 1px solid #ead7cc;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 12px 24px rgba(134, 40, 40, 0.06);
+}
+
+.timeline-column-header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.timeline-column-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.timeline-column-body {
+  overflow-y: auto;
+  max-height: calc(100vh - 300px);
+  padding-right: 6px;
 }
 
 .timeline {
@@ -1090,6 +1134,10 @@ button.ghost {
   font-size: 13px;
 }
 
+.compose-account-select {
+  margin-bottom: 12px;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     background: radial-gradient(circle at top left, #1d1b18, #12110f 55%, #0d0c0b);
@@ -1113,6 +1161,19 @@ button.ghost {
     background: #201412cc;
     border: 1px solid #4a2f2c;
     box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
+  }
+
+  .timeline-column {
+    background: #171512;
+    border: 1px solid #302822;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 12px 24px rgba(0, 0, 0, 0.35);
+  }
+
+  :root[data-theme="christmas"] .timeline-column,
+  body[data-theme="christmas"] .timeline-column {
+    background: #1a100f;
+    border: 1px solid #3b2624;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(64, 20, 20, 0.35);
   }
 
   .app-header p,
@@ -1427,6 +1488,7 @@ button.ghost {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  overflow: hidden;
 }
 
 @media (max-width: 900px) {
@@ -1454,5 +1516,18 @@ button.ghost {
 
   .brand-text p {
     color: #c4b6a6;
+  }
+
+  .timeline-board {
+    flex-direction: column;
+  }
+
+  .timeline-column {
+    flex: 1;
+    max-width: none;
+  }
+
+  .timeline-column-body {
+    max-height: none;
   }
 }


### PR DESCRIPTION
## Summary
- persist timeline sections in localStorage so added columns survive reloads
- separate compose account selection from timeline columns to avoid unintended switching
- keep section add action in header while retaining per-column controls

## Testing
- bun run build
