### PR TITLE
Move status timestamp below content

### DIFF
--- a/src/ui/components/TimelineItem.tsx
+++ b/src/ui/components/TimelineItem.tsx
@@ -74,6 +74,10 @@ export const TimelineItem = ({
       return boostedBy.handle;
     }
   }, [boostedBy]);
+  const timestamp = useMemo(
+    () => new Date(displayStatus.createdAt).toLocaleString(),
+    [displayStatus.createdAt]
+  );
   const contentParts = useMemo(() => {
     const text = displayStatus.content;
     const regex = /(https?:\/\/[^\s)\]]+)/g;
@@ -199,17 +203,6 @@ export const TimelineItem = ({
             )}
           </span>
         </div>
-        {displayStatus.url ? (
-          <a href={displayStatus.url} target="_blank" rel="noreferrer" className="time-link">
-            <time dateTime={displayStatus.createdAt}>
-              {new Date(displayStatus.createdAt).toLocaleString()}
-            </time>
-          </a>
-        ) : (
-          <time dateTime={displayStatus.createdAt}>
-            {new Date(displayStatus.createdAt).toLocaleString()}
-          </time>
-        )}
       </header>
       <p className="status-text">{displayStatus.content ? contentParts : "(내용 없음)"}</p>
       {previewCard ? (
@@ -229,6 +222,15 @@ export const TimelineItem = ({
           </div>
         </a>
       ) : null}
+      <div className="status-time">
+        {displayStatus.url ? (
+          <a href={displayStatus.url} target="_blank" rel="noreferrer" className="time-link">
+            <time dateTime={displayStatus.createdAt}>{timestamp}</time>
+          </a>
+        ) : (
+          <time dateTime={displayStatus.createdAt}>{timestamp}</time>
+        )}
+      </div>
       <footer>
         <div className="status-actions">
           <button type="button" onClick={() => onReply(displayStatus)}>
@@ -283,9 +285,7 @@ export const TimelineItem = ({
                   <strong>{displayStatus.accountName || displayStatus.accountHandle}</strong>
                   <span>@{displayHandle}</span>
                 </div>
-                <time dateTime={displayStatus.createdAt}>
-                  {new Date(displayStatus.createdAt).toLocaleString()}
-                </time>
+                <time dateTime={displayStatus.createdAt}>{timestamp}</time>
               </header>
               <p className="status-text confirm-text">
                 {displayStatus.content || "(내용 없음)"}

--- a/src/ui/styles/main.css
+++ b/src/ui/styles/main.css
@@ -703,7 +703,7 @@ button.ghost {
 
 .status header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   gap: 12px;
   font-size: 13px;
@@ -759,6 +759,17 @@ button.ghost {
   font-size: 15px;
   line-height: 1.5;
   white-space: pre-wrap;
+}
+
+.status-time {
+  margin-top: 10px;
+  font-size: 12px;
+  color: #8a6b58;
+}
+
+.status-time a {
+  color: inherit;
+  text-decoration: none;
 }
 
 .status-text a {
@@ -1216,6 +1227,10 @@ button.ghost {
 
   .status p {
     color: #f0e7dc;
+  }
+
+  .status-time {
+    color: #c4b6a6;
   }
 
   .replying {


### PR DESCRIPTION
## Summary
- reposition status timestamp to sit between the content and action buttons
- keep time link styling consistent and adjust header spacing
- add subtle styling for the relocated timestamp across themes

## Testing
- bun run build
