### PR TITLE
Fix boost indicators and visibility gating

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,13 @@ const TimelineSection = ({
       return;
     }
     onError(null);
+    const delta = status.reblogged ? -1 : 1;
+    const optimistic = {
+      ...status,
+      reblogged: !status.reblogged,
+      reblogsCount: Math.max(0, status.reblogsCount + delta)
+    };
+    timeline.updateItem(optimistic);
     try {
       const updated = status.reblogged
         ? await services.api.unreblog(account, status.id)
@@ -193,6 +200,7 @@ const TimelineSection = ({
       timeline.updateItem(updated);
     } catch (err) {
       onError(err instanceof Error ? err.message : "부스트 처리에 실패했습니다.");
+      timeline.updateItem(status);
     }
   };
 
@@ -293,17 +301,19 @@ const TimelineSection = ({
         {account && timeline.items.length > 0 ? (
           <div className="timeline">
             {timeline.items.map((status) => (
-              <TimelineItem
-                key={status.id}
-                status={status}
-                onReply={(item) => onReply(item, account)}
-                onToggleFavourite={handleToggleFavourite}
-                onToggleReblog={handleToggleReblog}
-                onDelete={handleDeleteStatus}
-                activeHandle={
-                  account.handle ? formatHandle(account.handle, account.instanceUrl) : account.instanceUrl
-                }
-              />
+                      <TimelineItem
+                        key={status.id}
+                        status={status}
+                        onReply={(item) => onReply(item, account)}
+                        onToggleFavourite={handleToggleFavourite}
+                        onToggleReblog={handleToggleReblog}
+                        onDelete={handleDeleteStatus}
+                        activeHandle={
+                          account.handle ? formatHandle(account.handle, account.instanceUrl) : account.instanceUrl
+                        }
+                        activeAccountHandle={account.handle ?? ""}
+                        activeAccountUrl={account.url ?? null}
+                      />
             ))}
           </div>
         ) : null}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -39,6 +39,7 @@ export type Status = {
   accountUrl: string | null;
   content: string;
   url: string | null;
+  visibility: Visibility;
   card: LinkCard | null;
   repliesCount: number;
   reblogsCount: number;

--- a/src/infra/MastodonHttpClient.ts
+++ b/src/infra/MastodonHttpClient.ts
@@ -112,6 +112,18 @@ export class MastodonHttpClient implements MastodonApi {
       headers: buildHeaders(account)
     });
     if (!response.ok) {
+      const errorBody = await response.text();
+      if (errorBody) {
+        try {
+          const data = JSON.parse(errorBody) as { error?: string; message?: string };
+          const message = data.error || data.message;
+          if (message) {
+            throw new Error(message);
+          }
+        } catch {
+          throw new Error(errorBody);
+        }
+      }
       throw new Error("요청에 실패했습니다.");
     }
     const data = (await response.json()) as unknown;

--- a/src/infra/mastodonMapper.ts
+++ b/src/infra/mastodonMapper.ts
@@ -88,6 +88,7 @@ export const mapStatus = (raw: unknown): Status => {
         : typeof value.uri === "string"
           ? value.uri
           : null,
+    visibility: (value.visibility as "public" | "unlisted" | "private" | "direct") ?? "public",
     card: cardUrl && hasCardData
       ? {
           url: cardUrl,

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -647,11 +647,30 @@ button.ghost {
   margin-top: 10px;
   font-size: 12px;
   color: #8a6b58;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .status-time a {
   color: inherit;
   text-decoration: none;
+}
+
+.visibility-icon {
+  width: 14px;
+  height: 14px;
+  color: inherit;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.time-separator {
+  font-size: 12px;
+  line-height: 1;
 }
 
 .status-text a {

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -107,6 +107,10 @@
   color: #2e6b4f;
 }
 
+:root[data-theme="christmas"] .status-time {
+  color: #2e6b4f;
+}
+
 :root[data-theme="christmas"] .link-preview {
   border: 1px solid #ead7cc;
   background: #fff7f2;
@@ -198,6 +202,11 @@
   body[data-theme="christmas"] .status header span,
   :root[data-theme="christmas"] .time-link,
   body[data-theme="christmas"] .time-link {
+    color: #9cc7ab;
+  }
+
+  :root[data-theme="christmas"] .status-time,
+  body[data-theme="christmas"] .status-time {
     color: #9cc7ab;
   }
 


### PR DESCRIPTION
## Summary
- show boost indicators immediately and reliably after toggling
- disable boost for own/private/direct posts and surface visibility
- add visibility icons alongside timestamps

## Testing
- not run