### PR TITLE
feat: 커스텀 이모지 표시 옵션 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,7 @@ const TimelineSection = ({
   canMoveLeft,
   canMoveRight,
   showProfileImage,
+  showCustomEmojis,
   registerTimelineListener,
   unregisterTimelineListener
 }: {
@@ -134,6 +135,7 @@ const TimelineSection = ({
   canMoveLeft: boolean;
   canMoveRight: boolean;
   showProfileImage: boolean;
+  showCustomEmojis: boolean;
   registerTimelineListener: (accountId: string, listener: (status: Status) => void) => void;
   unregisterTimelineListener: (accountId: string, listener: (status: Status) => void) => void;
 }) => {
@@ -364,6 +366,7 @@ const TimelineSection = ({
                         activeAccountHandle={account.handle ?? ""}
                         activeAccountUrl={account.url ?? null}
                         showProfileImage={showProfileImage}
+                        showCustomEmojis={showCustomEmojis}
                       />
             ))}
           </div>
@@ -387,6 +390,9 @@ export const App = () => {
   });
   const [showProfileImages, setShowProfileImages] = useState(() => {
     return localStorage.getItem("textodon.profileImages") !== "off";
+  });
+  const [showCustomEmojis, setShowCustomEmojis] = useState(() => {
+    return localStorage.getItem("textodon.customEmojis") !== "off";
   });
   const [settingsOpen, setSettingsOpen] = useState(false);
   const { services, accountsState } = useAppContext();
@@ -566,6 +572,10 @@ export const App = () => {
   useEffect(() => {
     localStorage.setItem("textodon.profileImages", showProfileImages ? "on" : "off");
   }, [showProfileImages]);
+
+  useEffect(() => {
+    localStorage.setItem("textodon.customEmojis", showCustomEmojis ? "on" : "off");
+  }, [showCustomEmojis]);
 
   useEffect(() => {
     setSections((current) =>
@@ -800,6 +810,7 @@ export const App = () => {
                       canMoveLeft={index > 0}
                       canMoveRight={index < sections.length - 1}
                       showProfileImage={showProfileImages}
+                      showCustomEmojis={showCustomEmojis}
                       registerTimelineListener={registerTimelineListener}
                       unregisterTimelineListener={unregisterTimelineListener}
                     />
@@ -858,6 +869,20 @@ export const App = () => {
                   type="checkbox"
                   checked={showProfileImages}
                   onChange={(event) => setShowProfileImages(event.target.checked)}
+                />
+                <span className="slider" aria-hidden="true" />
+              </label>
+            </div>
+            <div className="settings-item">
+              <div>
+                <strong>커스텀 이모지 표시</strong>
+                <p>사용자 이름과 본문에 커스텀 이모지를 표시합니다.</p>
+              </div>
+              <label className="switch">
+                <input
+                  type="checkbox"
+                  checked={showCustomEmojis}
+                  onChange={(event) => setShowCustomEmojis(event.target.checked)}
                 />
                 <span className="slider" aria-hidden="true" />
               </label>

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -27,6 +27,11 @@ export type Mention = {
   url: string | null;
 };
 
+export type CustomEmoji = {
+  shortcode: string;
+  url: string;
+};
+
 export type LinkCard = {
   url: string;
   title: string;
@@ -58,6 +63,8 @@ export type Status = {
   reblog: Status | null;
   boostedBy: { name: string; handle: string; url: string | null } | null;
   myReaction: string | null;
+  customEmojis: CustomEmoji[];
+  accountEmojis: CustomEmoji[];
 };
 
 export type TimelineItem = {

--- a/src/infra/mastodonMapper.ts
+++ b/src/infra/mastodonMapper.ts
@@ -60,6 +60,26 @@ const mapMentions = (
     );
 };
 
+const mapCustomEmojis = (emojis: unknown): { shortcode: string; url: string }[] => {
+  if (!Array.isArray(emojis)) {
+    return [];
+  }
+  return emojis
+    .map((item) => {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+      const typed = item as Record<string, unknown>;
+      const shortcode = typeof typed.shortcode === "string" ? typed.shortcode : "";
+      const url = typeof typed.url === "string" ? typed.url : "";
+      if (!shortcode || !url) {
+        return null;
+      }
+      return { shortcode, url };
+    })
+    .filter((item): item is { shortcode: string; url: string } => item !== null);
+};
+
 export const mapStatus = (raw: unknown): Status => {
   const value = raw as Record<string, unknown>;
   const account = (value.account ?? {}) as Record<string, unknown>;
@@ -78,6 +98,8 @@ export const mapStatus = (raw: unknown): Status => {
     typeof cardValue?.description === "string" ? cardValue.description : null;
   const cardImage = typeof cardValue?.image === "string" ? cardValue.image : null;
   const hasCardData = Boolean(cardTitle && cardTitle !== cardUrl) || Boolean(cardDescription || cardImage);
+  const customEmojis = mapCustomEmojis(value.emojis);
+  const accountEmojis = mapCustomEmojis(account.emojis);
   return {
     id: String(value.id ?? ""),
     createdAt: String(value.created_at ?? ""),
@@ -113,6 +135,8 @@ export const mapStatus = (raw: unknown): Status => {
     mediaAttachments: mapMediaAttachments(value.media_attachments),
     reblog,
     boostedBy: reblog ? { name: accountName, handle: accountHandle, url: accountUrl } : null,
-    myReaction: null
+    myReaction: null,
+    customEmojis,
+    accountEmojis
   };
 };

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -649,6 +649,13 @@ button.ghost {
   gap: 4px;
 }
 
+.custom-emoji {
+  width: 18px;
+  height: 18px;
+  vertical-align: -0.2em;
+  display: inline-block;
+}
+
 .status-avatar {
   width: 36px;
   height: 36px;


### PR DESCRIPTION
﻿## 요약
- 사용자 이름/본문의 :shortcode:를 커스텀 이모지 이미지로 렌더링합니다.
- 설정에서 커스텀 이모지 표시를 켜고 끌 수 있습니다.
- 마스토돈/미스키 커스텀 이모지 매핑을 보강했습니다.

## 테스트
- 미실행
