### PR TITLE
feat: 타임라인 드래그 스크롤 및 프로필 링크 복원

### DIFF
--- a/src/infra/MisskeyHttpClient.ts
+++ b/src/infra/MisskeyHttpClient.ts
@@ -1,6 +1,6 @@
 ﻿import type { Account, Status } from "../domain/types";
 import type { CreateStatusInput, MastodonApi } from "../services/MastodonApi";
-import { mapMisskeyStatus } from "./misskeyMapper";
+import { mapMisskeyStatusWithInstance } from "./misskeyMapper";
 
 const normalizeInstanceUrl = (instanceUrl: string): string => instanceUrl.replace(/\/$/, "");
 
@@ -63,7 +63,7 @@ export class MisskeyHttpClient implements MastodonApi {
       throw new Error("타임라인을 불러오지 못했습니다.");
     }
     const data = (await response.json()) as unknown[];
-    return data.map(mapMisskeyStatus);
+    return data.map((item) => mapMisskeyStatusWithInstance(item, account.instanceUrl));
   }
 
   async uploadMedia(account: Account, file: File): Promise<string> {
@@ -114,7 +114,7 @@ export class MisskeyHttpClient implements MastodonApi {
     if (!created) {
       throw new Error("생성된 노트를 찾을 수 없습니다.");
     }
-    return mapMisskeyStatus(created);
+    return mapMisskeyStatusWithInstance(created, account.instanceUrl);
   }
 
   async deleteStatus(account: Account, statusId: string): Promise<void> {
@@ -182,7 +182,7 @@ export class MisskeyHttpClient implements MastodonApi {
 
   private async fetchNote(account: Account, noteId: string): Promise<Status> {
     const data = await this.fetchNoteRaw(account, noteId);
-    return mapMisskeyStatus(data);
+    return mapMisskeyStatusWithInstance(data, account.instanceUrl);
   }
 
   private async postSimple(account: Account, path: string, payload: Record<string, unknown>) {

--- a/src/infra/misskeyMapper.ts
+++ b/src/infra/misskeyMapper.ts
@@ -121,14 +121,35 @@ const sumReactions = (reactions: unknown): number => {
   }, 0);
 };
 
-export const mapMisskeyStatus = (raw: unknown): Status => {
+const buildAccountUrl = (
+  user: Record<string, unknown>,
+  instanceUrl?: string
+): string | null => {
+  const url = typeof user.url === "string" ? user.url : null;
+  if (url) {
+    return url;
+  }
+  const uri = typeof user.uri === "string" ? user.uri : null;
+  if (uri) {
+    return uri;
+  }
+  const username = typeof user.username === "string" ? user.username : "";
+  if (!username || !instanceUrl) {
+    return null;
+  }
+  const host = typeof user.host === "string" ? user.host : "";
+  const base = host ? `https://${host}` : instanceUrl;
+  return `${base.replace(/\/$/, "")}/@${username}`;
+};
+
+export const mapMisskeyStatusWithInstance = (raw: unknown, instanceUrl?: string): Status => {
   const value = raw as Record<string, unknown>;
   const user = (value.user ?? {}) as Record<string, unknown>;
   const renoteValue = value.renote as Record<string, unknown> | null | undefined;
-  const renote = renoteValue ? mapMisskeyStatus(renoteValue) : null;
+  const renote = renoteValue ? mapMisskeyStatusWithInstance(renoteValue, instanceUrl) : null;
   const accountName = String(user.name ?? user.username ?? "");
   const accountHandle = String(user.username ?? "");
-  const accountUrl = typeof user.url === "string" ? user.url : null;
+  const accountUrl = buildAccountUrl(user, instanceUrl);
   const accountAvatarUrl = typeof user.avatarUrl === "string" ? user.avatarUrl : null;
   const text = String(value.text ?? "");
   const spoilerText = typeof value.cw === "string" ? value.cw : "";
@@ -185,4 +206,8 @@ export const mapMisskeyStatus = (raw: unknown): Status => {
     customEmojis,
     accountEmojis
   };
+};
+
+export const mapMisskeyStatus = (raw: unknown): Status => {
+  return mapMisskeyStatusWithInstance(raw);
 };

--- a/src/ui/components/TimelineItem.tsx
+++ b/src/ui/components/TimelineItem.tsx
@@ -97,6 +97,37 @@ export const TimelineItem = ({
     () => new Date(displayStatus.createdAt).toLocaleString(),
     [displayStatus.createdAt]
   );
+  const handleHeaderClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (!displayStatus.accountUrl) {
+        return;
+      }
+      const target =
+        event.target instanceof Element
+          ? event.target
+          : event.target && "parentElement" in event.target
+            ? (event.target as Node).parentElement
+            : null;
+      if (target?.closest("a")) {
+        return;
+      }
+      window.open(displayStatus.accountUrl, "_blank", "noopener,noreferrer");
+    },
+    [displayStatus.accountUrl]
+  );
+  const handleHeaderKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (!displayStatus.accountUrl) {
+        return;
+      }
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      window.open(displayStatus.accountUrl, "_blank", "noopener,noreferrer");
+    },
+    [displayStatus.accountUrl]
+  );
   const visibilityIcon = useMemo(() => {
     switch (displayStatus.visibility) {
       case "public":
@@ -369,7 +400,19 @@ export const TimelineItem = ({
           <span>{mentionNames} 님께 보낸 댓글</span>
         </div>
       ) : null}
-      <header className="status-header-main">
+      <header
+        className="status-header-main"
+        onClick={handleHeaderClick}
+        onKeyDown={handleHeaderKeyDown}
+        role={displayStatus.accountUrl ? "link" : undefined}
+        tabIndex={displayStatus.accountUrl ? 0 : undefined}
+        aria-label={
+          displayStatus.accountUrl
+            ? `${displayStatus.accountName || displayStatus.accountHandle} 프로필 열기`
+            : undefined
+        }
+        data-interactive={displayStatus.accountUrl ? "true" : undefined}
+      >
         {showProfileImage ? (
           <span className="status-avatar">
             {displayStatus.accountAvatarUrl ? (

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -555,6 +555,13 @@ button.ghost {
   gap: 16px;
   overflow-x: auto;
   padding-bottom: 2px;
+  cursor: grab;
+  scroll-behavior: smooth;
+}
+
+.timeline-board.is-dragging {
+  cursor: grabbing;
+  user-select: none;
 }
 
 .timeline-column {
@@ -641,6 +648,10 @@ button.ghost {
   gap: 12px;
   font-size: 13px;
   color: #6b5c4f;
+}
+
+.status-header-main {
+  cursor: pointer;
 }
 
 .status header div {


### PR DESCRIPTION
﻿## 요약
- 타임라인 컬럼을 드래그로 좌우 스크롤할 수 있게 했습니다.
- 프로필 헤더 클릭 이동을 복원하고 키보드 접근성을 보강했습니다.
- 미스키 프로필 URL 매핑을 보강해 프로필 이동이 동작하도록 했습니다.

## 테스트
- 미실행
