### PR TITLE
커스텀 이모지 팔렛트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -905,6 +905,8 @@ export const App = () => {
             {composeAccount ? (
               <ComposeBox
                 accountSelector={composeAccountSelector}
+                account={composeAccount}
+                api={services.api}
                 onSubmit={handleSubmit}
                 replyingTo={replyTarget ? { id: replyTarget.id, summary: replySummary ?? "" } : null}
                 onCancelReply={() => {
@@ -1034,6 +1036,8 @@ export const App = () => {
             {composeAccount ? (
               <ComposeBox
                 accountSelector={composeAccountSelector}
+                account={composeAccount}
+                api={services.api}
                 onSubmit={handleSubmit}
                 replyingTo={replyTarget ? { id: replyTarget.id, summary: replySummary ?? "" } : null}
                 onCancelReply={() => {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -30,6 +30,7 @@ export type Mention = {
 export type CustomEmoji = {
   shortcode: string;
   url: string;
+  category?: string | null;
 };
 
 export type Reaction = {

--- a/src/infra/UnifiedApiClient.ts
+++ b/src/infra/UnifiedApiClient.ts
@@ -1,4 +1,5 @@
 import type { Account } from "../domain/types";
+import type { CustomEmoji } from "../domain/types";
 import type { CreateStatusInput, MastodonApi } from "../services/MastodonApi";
 
 export class UnifiedApiClient implements MastodonApi {
@@ -17,6 +18,10 @@ export class UnifiedApiClient implements MastodonApi {
 
   fetchHomeTimeline(account: Account, limit: number, maxId?: string) {
     return this.getClient(account).fetchHomeTimeline(account, limit, maxId);
+  }
+
+  fetchCustomEmojis(account: Account): Promise<CustomEmoji[]> {
+    return this.getClient(account).fetchCustomEmojis(account);
   }
 
   uploadMedia(account: Account, file: File) {

--- a/src/services/MastodonApi.ts
+++ b/src/services/MastodonApi.ts
@@ -1,4 +1,5 @@
 import type { Account, Status, Visibility } from "../domain/types";
+import type { CustomEmoji } from "../domain/types";
 
 export type CreateStatusInput = {
   status: string;
@@ -10,6 +11,7 @@ export type CreateStatusInput = {
 export interface MastodonApi {
   verifyAccount(account: Account): Promise<{ accountName: string; handle: string; avatarUrl: string | null }>;
   fetchHomeTimeline(account: Account, limit: number, maxId?: string): Promise<Status[]>;
+  fetchCustomEmojis(account: Account): Promise<CustomEmoji[]>;
   uploadMedia(account: Account, file: File): Promise<string>;
   createStatus(account: Account, input: CreateStatusInput): Promise<Status>;
   deleteStatus(account: Account, statusId: string): Promise<void>;

--- a/src/ui/components/TimelineItem.tsx
+++ b/src/ui/components/TimelineItem.tsx
@@ -179,7 +179,7 @@ export const TimelineItem = ({
   }, []);
 
   const tokenizeWithEmojis = useCallback((text: string, emojiMap: Map<string, string>) => {
-    const regex = /:([a-zA-Z0-9_+-]+):/g;
+    const regex = /:([a-zA-Z0-9_+@.-]+):/g;
     const tokens: Array<{ type: "text"; value: string } | { type: "emoji"; name: string; url: string }> = [];
     let lastIndex = 0;
     let match: RegExpExecArray | null;

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -470,6 +470,85 @@
   font-family: inherit;
 }
 
+.compose-icon-button {
+  background: #e1e7f4;
+  color: #1e2b45;
+  border: 1px solid #d8d1c7;
+}
+
+.compose-icon-button:disabled {
+  opacity: 0.5;
+}
+
+.compose-emoji-panel {
+  margin-top: 12px;
+  border: 1px solid #e2ddd5;
+  border-radius: 12px;
+  background: #fffdfa;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.compose-emoji-empty {
+  font-size: 12px;
+  color: #6c5c4b;
+  margin: 0;
+}
+
+.compose-emoji-category {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.compose-emoji-category-toggle {
+  background: #f3efe7;
+  color: #1e2b45;
+  border: 1px solid #e2ddd5;
+  border-radius: 10px;
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.compose-emoji-count {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #d7e0f2;
+  color: #1e2b45;
+}
+
+.compose-emoji-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+  gap: 6px;
+}
+
+.compose-emoji-button {
+  width: 36px;
+  height: 36px;
+  padding: 4px;
+  border-radius: 8px;
+  background: #f3f0e9;
+  border: 1px solid #e2ddd5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.compose-emoji-button img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 button {
   font-family: inherit;
   background: #3b5fa8;
@@ -679,10 +758,16 @@ button.ghost {
 }
 
 .custom-emoji {
-  width: 18px;
-  height: 18px;
-  vertical-align: -0.2em;
+  width: auto;
+  height: 1.5em;
+  vertical-align: -0.25em;
   display: inline-block;
+  transition: transform 0.15s ease;
+  transform-origin: center;
+}
+
+.custom-emoji:hover {
+  transform: scale(2);
 }
 
 .status-avatar {
@@ -954,11 +1039,12 @@ button.ghost {
   background: #e1e7f4;
   color: #1e2b45;
   border-radius: 10px;
-  padding: 8px 12px;
+  padding: 0;
   cursor: pointer;
   font-size: 13px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 }
 
 .file-button input {

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -145,6 +145,13 @@ body[data-theme="christmas"] .status-warning-text {
   color: #7b3f3f;
 }
 
+:root[data-theme="christmas"] .compose-icon-button,
+body[data-theme="christmas"] .compose-icon-button {
+  background: #f3e4dc;
+  color: #7b3f3f;
+  border-color: #ead7cc;
+}
+
 :root[data-theme="christmas"] .boosted-by {
   color: #2e6b4f;
 }
@@ -514,10 +521,73 @@ body[data-theme="christmas"] .status-warning-text {
     color: #e1e7f4;
   }
 
+  .compose-icon-button {
+    background: #2c3b59;
+    color: #e1e7f4;
+    border-color: #3b342d;
+  }
+
   :root[data-theme="christmas"] .file-button,
   body[data-theme="christmas"] .file-button {
     background: #2a1b19;
     color: #f7e7df;
+  }
+
+  :root[data-theme="christmas"] .compose-icon-button,
+  body[data-theme="christmas"] .compose-icon-button {
+    background: #2a1b19;
+    color: #f7e7df;
+    border-color: #3b2624;
+  }
+
+  .compose-emoji-panel {
+    background: #1b1916;
+    border-color: #3b342d;
+  }
+
+  :root[data-theme="christmas"] .compose-emoji-panel,
+  body[data-theme="christmas"] .compose-emoji-panel {
+    background: #201412;
+    border-color: #3b2624;
+  }
+
+  .compose-emoji-category-toggle {
+    background: #2a2622;
+    color: #f0e7dc;
+    border-color: #3b342d;
+  }
+
+  :root[data-theme="christmas"] .compose-emoji-category-toggle,
+  body[data-theme="christmas"] .compose-emoji-category-toggle {
+    background: #2a1b19;
+    color: #f7e7df;
+    border-color: #3b2624;
+  }
+
+  .compose-emoji-count {
+    background: #2c3b59;
+    color: #e1e7f4;
+  }
+
+  :root[data-theme="christmas"] .compose-emoji-count,
+  body[data-theme="christmas"] .compose-emoji-count {
+    background: #3b2624;
+    color: #f7e7df;
+  }
+
+  .compose-emoji-button {
+    background: #221f1b;
+    border-color: #3b342d;
+  }
+
+  :root[data-theme="christmas"] .compose-emoji-button,
+  body[data-theme="christmas"] .compose-emoji-button {
+    background: #1a100f;
+    border-color: #3b2624;
+  }
+
+  .compose-emoji-empty {
+    color: #c4b6a6;
   }
 
   .link-preview {


### PR DESCRIPTION
## 요약
- 작성 박스에 커스텀 이모지 팔렛트를 추가하고 최근 사용/카테고리 토글을 지원
- 서버별 커스텀 이모지 API 연동 및 미스키 이모지 매핑 보완
- 커스텀 이모지 렌더링/크기/호버 동작 개선

## 테스트
- 미실행
