### PR TITLE
아이콘 버튼 및 서버 추가 패널 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -960,14 +960,22 @@ export const App = () => {
               <p className="sidebar-description">
                 여러 계정을 전환하고 타임라인을 실시간으로 확인할 수 있습니다.
               </p>
-              <button
-                type="button"
-                className="settings-button"
-                onClick={() => setSettingsOpen(true)}
-              >
-                설정 열기
-              </button>
               <div className="sidebar-actions">
+                <button
+                  type="button"
+                  className="settings-button button-with-icon"
+                  onClick={() => setSettingsOpen(true)}
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M4 6h16" />
+                    <circle cx="9" cy="6" r="2" />
+                    <path d="M4 12h16" />
+                    <circle cx="15" cy="12" r="2" />
+                    <path d="M4 18h16" />
+                    <circle cx="8" cy="18" r="2" />
+                  </svg>
+                  설정 열기
+                </button>
                 <AccountAdd
                   accounts={accountsState.accounts}
                   setActiveAccount={accountsState.setActiveAccount}
@@ -1095,11 +1103,20 @@ export const App = () => {
             <div className="mobile-menu-actions">
               <button
                 type="button"
+                className="button-with-icon"
                 onClick={() => {
                   setSettingsOpen(true);
                   closeMobileMenu();
                 }}
               >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 6h16" />
+                  <circle cx="9" cy="6" r="2" />
+                  <path d="M4 12h16" />
+                  <circle cx="15" cy="12" r="2" />
+                  <path d="M4 18h16" />
+                  <circle cx="8" cy="18" r="2" />
+                </svg>
                 설정 열기
               </button>
             </div>

--- a/src/ui/components/AccountAdd.tsx
+++ b/src/ui/components/AccountAdd.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import type { Account } from "../../domain/types";
 import type { OAuthClient } from "../../services/OAuthClient";
 import { normalizeInstanceUrl } from "../utils/account";
@@ -17,26 +17,6 @@ export const AccountAdd = ({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [showForm, setShowForm] = useState(false);
-  const popoverRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!showForm) {
-      return;
-    }
-    const handleClick = (event: MouseEvent) => {
-      if (!popoverRef.current || !(event.target instanceof Node)) {
-        return;
-      }
-      if (!popoverRef.current.contains(event.target)) {
-        setShowForm(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-    };
-  }, [showForm]);
-
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setError(null);
@@ -81,43 +61,47 @@ export const AccountAdd = ({
   };
 
   return (
-    <div className="account-add">
+    <div className="account-add-wrapper">
       <button
         type="button"
-        className="account-add-button header"
+        className="account-add-button header button-with-icon"
         onClick={() => setShowForm((prev) => !prev)}
         aria-label={showForm ? "서버 추가 닫기" : "서버 추가"}
         aria-expanded={showForm}
       >
-        {showForm ? "?" : "+"} 서버 추가
+        {showForm ? (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 6l12 12" />
+            <path d="M18 6l-12 12" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 5v14" />
+            <path d="M5 12h14" />
+          </svg>
+        )}
+        {showForm ? "서버 추가 닫기" : "서버 추가"}
       </button>
 
       {showForm ? (
-        <>
-          <div
-            className="overlay-backdrop"
-            onClick={() => setShowForm(false)}
-            aria-hidden="true"
-          />
-          <div className="account-add-popover" ref={popoverRef}>
-            <form className="account-form" onSubmit={handleSubmit}>
-              <label>
-                서버 주소
-                <input
-                  type="text"
-                  placeholder="mastodon.social"
-                  value={instanceUrl}
-                  onChange={(event) => setInstanceUrl(event.target.value)}
-                />
-              </label>
-              {error ? <p className="error">{error}</p> : null}
-              <button type="submit" disabled={loading}>
-                {loading ? "연결 중..." : "OAuth로 연결"}
-              </button>
-            </form>
-            <p className="hint">OAuth 승인 후 자동으로 돌아옵니다.</p>
-          </div>
-        </>
+        <div className="account-add-panel">
+          <form className="account-form" onSubmit={handleSubmit}>
+            <label>
+              서버 주소
+              <input
+                type="text"
+                placeholder="mastodon.social"
+                value={instanceUrl}
+                onChange={(event) => setInstanceUrl(event.target.value)}
+              />
+            </label>
+            {error ? <p className="error">{error}</p> : null}
+            <button type="submit" disabled={loading}>
+              {loading ? "연결 중..." : "OAuth로 연결"}
+            </button>
+          </form>
+          <p className="hint">OAuth 승인 후 자동으로 돌아옵니다.</p>
+        </div>
       ) : null}
     </div>
   );

--- a/src/ui/components/AccountManager.tsx
+++ b/src/ui/components/AccountManager.tsx
@@ -102,11 +102,22 @@ export const AccountManager = ({
 
       <button
         type="button"
-        className="account-add-button"
+        className="account-add-button button-with-icon"
         onClick={() => setShowForm((prev) => !prev)}
         aria-label={showForm ? "서버 추가 닫기" : "서버 추가"}
       >
-        {showForm ? "–" : "+"} 서버 추가
+        {showForm ? (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 6l12 12" />
+            <path d="M18 6l-12 12" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 5v14" />
+            <path d="M5 12h14" />
+          </svg>
+        )}
+        {showForm ? "서버 추가 닫기" : "서버 추가"}
       </button>
 
       {showForm ? (

--- a/src/ui/components/ComposeBox.tsx
+++ b/src/ui/components/ComposeBox.tsx
@@ -439,7 +439,16 @@ export const ComposeBox = ({
               </svg>
               <input type="file" accept="image/*" multiple onChange={handleFilesSelected} />
             </label>
-            <button type="submit">게시</button>
+            <button
+              type="submit"
+              className="icon-button compose-icon-button"
+              aria-label="게시"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M22 2L11 13" />
+                <path d="M22 2l-7 20-4-9-9-4 20-7z" />
+              </svg>
+            </button>
           </div>
         </div>
         {emojiPanelOpen ? (

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -17,19 +17,30 @@
 
 .settings-button {
   width: 100%;
-  margin: 6px 0 0;
+  margin: 0;
 }
 
 .sidebar-actions {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   margin-top: 8px;
 }
 
-.sidebar-actions .account-add,
+.sidebar-actions .settings-button {
+  height: 40px;
+}
+
+.sidebar-actions .account-add-wrapper {
+  display: contents;
+}
+
 .sidebar-actions .account-add-button.header {
   width: 100%;
+}
+
+.sidebar-actions .account-add-panel {
+  grid-column: 1 / -1;
 }
 
 .sidebar-divider {
@@ -130,10 +141,6 @@
   margin-bottom: 12px;
 }
 
-.account-add {
-  position: relative;
-}
-
 .account-add-button.header {
   width: auto;
   height: 40px;
@@ -142,24 +149,15 @@
   font-size: 13px;
 }
 
-.account-add-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  width: min(320px, 80vw);
+.account-add-panel {
+  width: 100%;
+  max-width: 100%;
   background: #fffdfa;
   border: 1px solid #e2ddd5;
   border-radius: 12px;
   padding: 12px;
   box-shadow: 0 18px 40px rgba(67, 57, 45, 0.12);
-  z-index: 30;
-}
-
-.overlay-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 13, 11, 0.12);
-  z-index: 15;
+  margin-top: 8px;
 }
 
 .settings-modal {
@@ -229,7 +227,7 @@
   font-family: inherit;
 }
 
-.settings-item .account-add {
+.settings-item .account-add-wrapper {
   flex-shrink: 0;
 }
 
@@ -564,6 +562,23 @@ button {
   border-radius: 10px;
   padding: 8px 12px;
   cursor: pointer;
+}
+
+.button-with-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.button-with-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .icon-button {

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -41,7 +41,7 @@ body[data-theme="christmas"] .overlay-backdrop {
   color: #f4fff7;
 }
 
-:root[data-theme="christmas"] .account-add-popover {
+:root[data-theme="christmas"] .account-add-panel {
   background: rgba(255, 247, 242, 0.92);
   color: #5b1f1f;
   border: 1px solid #ead7cc;
@@ -278,7 +278,7 @@ body[data-theme="monochrome"] .overlay-backdrop {
   color: #ffffff;
 }
 
-:root[data-theme="monochrome"] .account-add-popover {
+:root[data-theme="monochrome"] .account-add-panel {
   background: rgba(255, 255, 255, 0.92);
   color: #111111;
   border: 1px solid #1d1d1d;
@@ -824,23 +824,23 @@ body[data-theme="monochrome"] .compose-icon-button {
     color: #111111;
   }
 
-  .account-add-popover {
+  .account-add-panel {
     background: rgba(23, 21, 18, 0.88);
     color: #f0e7dc;
     border: 1px solid #3b342d;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  :root[data-theme="christmas"] .account-add-popover,
-  body[data-theme="christmas"] .account-add-popover {
+  :root[data-theme="christmas"] .account-add-panel,
+  body[data-theme="christmas"] .account-add-panel {
     background: rgba(26, 16, 15, 0.88);
     color: #f7e7df;
     border: 1px solid #3b2624;
     box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
   }
 
-  :root[data-theme="monochrome"] .account-add-popover,
-  body[data-theme="monochrome"] .account-add-popover {
+  :root[data-theme="monochrome"] .account-add-panel,
+  body[data-theme="monochrome"] .account-add-panel {
     background: rgba(16, 16, 16, 0.88);
     color: #f0f0f0;
     border: 1px solid #3a3a3a;


### PR DESCRIPTION
## 요약
- 글쓰기 게시 버튼과 설정/서버 추가 버튼을 아이콘 기반으로 정리했습니다.
- 서버 추가 뷰를 팝오버 대신 하단 패널로 전환하고, 설명 박스 내부에 배치했습니다.
- 서버 추가 패널은 하단 디바이더만 남기고 간소화했습니다.

## 변경 사항
- 글쓰기 패널의 게시 버튼을 아이콘 버튼으로 변경했습니다.
- 설정 열기와 서버 추가 버튼을 같은 라인에 배치했습니다.
- 서버 추가 뷰를 하단 패널 노출로 변경했습니다.
- 테마별 스타일과 디바이더 색상을 조정했습니다.

## 테스트
- 미실행 (UI 확인 필요)
