### PR TITLE
베타 배포: GitHub Pages 환경 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
+      name: github-pages-beta
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages (Beta)


### PR DESCRIPTION
## 요약
- 베타 배포 워크플로의 GitHub Pages 환경을 분리

## 테스트
- 해당 없음