### PR TITLE
feat: 색상 모드 고정 옵션 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -424,8 +424,22 @@ const getStoredTheme = (): ThemeMode => {
   return localStorage.getItem("textodon.christmas") === "on" ? "christmas" : "default";
 };
 
+type ColorScheme = "system" | "light" | "dark";
+
+const isColorScheme = (value: string): value is ColorScheme =>
+  value === "system" || value === "light" || value === "dark";
+
+const getStoredColorScheme = (): ColorScheme => {
+  const storedScheme = localStorage.getItem("textodon.colorScheme");
+  if (storedScheme && isColorScheme(storedScheme)) {
+    return storedScheme;
+  }
+  return "system";
+};
+
 export const App = () => {
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => getStoredTheme());
+  const [colorScheme, setColorScheme] = useState<ColorScheme>(() => getStoredColorScheme());
   const [sectionSize, setSectionSize] = useState<"small" | "medium" | "large">(() => {
     const stored = localStorage.getItem("textodon.sectionSize");
     if (stored === "medium" || stored === "large" || stored === "small") {
@@ -632,6 +646,17 @@ export const App = () => {
     localStorage.setItem("textodon.theme", themeMode);
     localStorage.setItem("textodon.christmas", themeMode === "christmas" ? "on" : "off");
   }, [themeMode]);
+
+  useEffect(() => {
+    if (colorScheme === "system") {
+      delete document.documentElement.dataset.colorScheme;
+      delete document.body.dataset.colorScheme;
+    } else {
+      document.documentElement.dataset.colorScheme = colorScheme;
+      document.body.dataset.colorScheme = colorScheme;
+    }
+    localStorage.setItem("textodon.colorScheme", colorScheme);
+  }, [colorScheme]);
 
   useEffect(() => {
     document.documentElement.dataset.sectionSize = sectionSize;
@@ -1152,6 +1177,26 @@ export const App = () => {
                 <option value="christmas">크리스마스</option>
                 <option value="sky-pink">하늘핑크</option>
                 <option value="monochrome">모노톤</option>
+              </select>
+            </div>
+            <div className="settings-item">
+              <div>
+                <strong>색상 모드</strong>
+                <p>시스템 설정을 따르거나 라이트/다크 모드를 고정합니다.</p>
+              </div>
+              <select
+                value={colorScheme}
+                onChange={(event) => {
+                  const nextScheme = event.target.value;
+                  if (isColorScheme(nextScheme)) {
+                    setColorScheme(nextScheme);
+                  }
+                }}
+                aria-label="색상 모드 선택"
+              >
+                <option value="system">시스템</option>
+                <option value="light">라이트</option>
+                <option value="dark">다크</option>
               </select>
             </div>
             <div className="settings-item">

--- a/src/ui/styles/base.css
+++ b/src/ui/styles/base.css
@@ -9,6 +9,14 @@
   --timeline-column-max-width: 520px;
 }
 
+:root[data-color-scheme="light"] {
+  color-scheme: light;
+}
+
+:root[data-color-scheme="dark"] {
+  color-scheme: dark;
+}
+
 :root[data-theme="christmas"] {
   background: radial-gradient(circle at top left, #f6efe6, #fff5f0 55%, #ffffff);
   color: #2d1a16;

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -738,1185 +738,2528 @@ body[data-theme="monochrome"] .compose-icon-button {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-color-scheme="light"]) {
     background: radial-gradient(circle at top left, #1d1b18, #12110f 55%, #0d0c0b);
     color: #f0e7dc;
     --scrollbar-thumb: var(--scrollbar-thumb-dark);
   }
 
-  :root[data-theme="christmas"],
-  body[data-theme="christmas"] {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"],
+  body:not([data-color-scheme="light"])[data-theme="christmas"] {
     background: radial-gradient(circle at top left, #2a1716, #1d1110 55%, #120b0a);
     color: #f7e7df;
   }
 
-  :root[data-theme="sky-pink"],
-  body[data-theme="sky-pink"] {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"],
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] {
     background: radial-gradient(circle at top left, #1b2330, #191a26 55%, #101218);
     color: #eff1f7;
     --scrollbar-thumb: #5f6875;
   }
 
-  :root[data-theme="monochrome"],
-  body[data-theme="monochrome"] {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"],
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] {
     background: radial-gradient(circle at top left, #0f0f0f, #080808 55%, #030303);
     color: #f5f5f5;
     --scrollbar-thumb: #616161;
   }
 
-  .overlay-backdrop {
+  :root:not([data-color-scheme="light"]) .overlay-backdrop,
+  body:not([data-color-scheme="light"]) .overlay-backdrop {
     background: rgba(15, 13, 11, 0.4);
   }
 
-  :root[data-theme="christmas"] .overlay-backdrop,
-  body[data-theme="christmas"] .overlay-backdrop {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .overlay-backdrop,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .overlay-backdrop {
     background: rgba(32, 16, 15, 0.45);
   }
 
-  :root[data-theme="sky-pink"] .overlay-backdrop,
-  body[data-theme="sky-pink"] .overlay-backdrop {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .overlay-backdrop,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .overlay-backdrop {
     background: rgba(88, 102, 138, 0.35);
   }
 
-  :root[data-theme="monochrome"] .overlay-backdrop,
-  body[data-theme="monochrome"] .overlay-backdrop {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .overlay-backdrop,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .overlay-backdrop {
     background: rgba(0, 0, 0, 0.5);
   }
 
-  .panel {
+  :root:not([data-color-scheme="light"]) .panel,
+  body:not([data-color-scheme="light"]) .panel {
     background: #1b1916cc;
     border: 1px solid #3b342d;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  :root[data-theme="christmas"] .panel,
-  body[data-theme="christmas"] .panel {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .panel,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .panel {
     background: #201412cc;
     border: 1px solid #4a2f2c;
     box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
   }
 
-  :root[data-theme="sky-pink"] .panel,
-  body[data-theme="sky-pink"] .panel {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .panel,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .panel {
     background: #1a202dcc;
     border: 1px solid #2e3b50;
     box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
   }
 
-  :root[data-theme="monochrome"] .panel,
-  body[data-theme="monochrome"] .panel {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .panel,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .panel {
     background: #121212cc;
     border: 1px solid #3a3a3a;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  .timeline-column {
+  :root:not([data-color-scheme="light"]) .timeline-column,
+  body:not([data-color-scheme="light"]) .timeline-column {
     background: #171512;
     border: 1px solid #302822;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 12px 24px rgba(0, 0, 0, 0.35);
   }
 
-  :root[data-theme="christmas"] .timeline-column,
-  body[data-theme="christmas"] .timeline-column {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .timeline-column,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .timeline-column {
     background: #1a100f;
     border: 1px solid #3b2624;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(64, 20, 20, 0.35);
   }
 
-  :root[data-theme="sky-pink"] .timeline-column,
-  body[data-theme="sky-pink"] .timeline-column {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .timeline-column,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .timeline-column {
     background: #181e2a;
     border: 1px solid #2e3b50;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(12, 18, 28, 0.35);
   }
 
-  :root[data-theme="monochrome"] .timeline-column,
-  body[data-theme="monochrome"] .timeline-column {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .timeline-column,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .timeline-column {
     background: #101010;
     border: 1px solid #3a3a3a;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(0, 0, 0, 0.35);
   }
 
-  .app-header p,
-  .status header,
-  .account-list .ghost,
-  .attachments a,
-  .empty,
-  .hint {
+  :root:not([data-color-scheme="light"]) .app-header p,
+  body:not([data-color-scheme="light"]) .app-header p,
+  :root:not([data-color-scheme="light"]) .status header,
+  body:not([data-color-scheme="light"]) .status header,
+  :root:not([data-color-scheme="light"]) .account-list .ghost,
+  body:not([data-color-scheme="light"]) .account-list .ghost,
+  :root:not([data-color-scheme="light"]) .attachments a,
+  body:not([data-color-scheme="light"]) .attachments a,
+  :root:not([data-color-scheme="light"]) .empty,
+  body:not([data-color-scheme="light"]) .empty,
+  :root:not([data-color-scheme="light"]) .hint,
+  body:not([data-color-scheme="light"]) .hint {
     color: #c4b6a6;
   }
 
-  :root[data-theme="monochrome"] .app-header p,
-  body[data-theme="monochrome"] .app-header p,
-  :root[data-theme="monochrome"] .status header,
-  body[data-theme="monochrome"] .status header,
-  :root[data-theme="monochrome"] .account-list .ghost,
-  body[data-theme="monochrome"] .account-list .ghost,
-  :root[data-theme="monochrome"] .attachments a,
-  body[data-theme="monochrome"] .attachments a,
-  :root[data-theme="monochrome"] .empty,
-  body[data-theme="monochrome"] .empty,
-  :root[data-theme="monochrome"] .hint,
-  body[data-theme="monochrome"] .hint {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .app-header p,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .app-header p,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status header,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status header,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-list .ghost,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-list .ghost,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .attachments a,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .attachments a,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .empty,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .empty,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .hint,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .hint {
     color: #d6d6d6;
   }
 
-  .status {
+  :root:not([data-color-scheme="light"]) .status,
+  body:not([data-color-scheme="light"]) .status {
     background: #171512;
     border: 1px solid #302822;
   }
 
-  :root[data-theme="christmas"] .status,
-  body[data-theme="christmas"] .status {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status {
     background: #1a100f;
     border: 1px solid #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .status,
-  body[data-theme="sky-pink"] .status {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status {
     background: #181e2a;
     border: 1px solid #2e3b50;
   }
 
-  :root[data-theme="monochrome"] .status,
-  body[data-theme="monochrome"] .status {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status {
     background: #101010;
     border: 1px solid #3a3a3a;
   }
 
-  :root[data-theme="christmas"] .status header,
-  body[data-theme="christmas"] .status header {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status header,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status header {
     color: #e4b9b9;
   }
 
-  :root[data-theme="christmas"] .status header strong,
-  body[data-theme="christmas"] .status header strong {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status header strong,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status header strong {
     color: #f4d7d7;
   }
 
-  :root[data-theme="christmas"] .status header span,
-  body[data-theme="christmas"] .status header span,
-  :root[data-theme="christmas"] .time-link,
-  body[data-theme="christmas"] .time-link {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status header span,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status header span,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .time-link,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .time-link {
     color: #9cc7ab;
   }
 
-  :root[data-theme="sky-pink"] .status header,
-  body[data-theme="sky-pink"] .status header {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status header,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status header {
     color: #d7ddea;
   }
 
-  :root[data-theme="sky-pink"] .status header strong,
-  body[data-theme="sky-pink"] .status header strong {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status header strong,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status header strong {
     color: #f2f5fb;
   }
 
-  :root[data-theme="sky-pink"] .status header span,
-  body[data-theme="sky-pink"] .status header span,
-  :root[data-theme="sky-pink"] .time-link,
-  body[data-theme="sky-pink"] .time-link {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status header span,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status header span,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .time-link,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .time-link {
     color: #f0a6c8;
   }
 
-  :root[data-theme="monochrome"] .status header,
-  body[data-theme="monochrome"] .status header {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status header,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status header {
     color: #d6d6d6;
   }
 
-  :root[data-theme="monochrome"] .status header strong,
-  body[data-theme="monochrome"] .status header strong {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status header strong,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status header strong {
     color: #f5f5f5;
   }
 
-  :root[data-theme="monochrome"] .status header span,
-  body[data-theme="monochrome"] .status header span,
-  :root[data-theme="monochrome"] .time-link,
-  body[data-theme="monochrome"] .time-link {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status header span,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status header span,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .time-link,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .time-link {
     color: #bdbdbd;
   }
 
-  :root[data-theme="christmas"] .status-time,
-  body[data-theme="christmas"] .status-time {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status-time,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status-time {
     color: #9cc7ab;
   }
 
-  :root[data-theme="sky-pink"] .status-time,
-  body[data-theme="sky-pink"] .status-time {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-time,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-time {
     color: #f0a6c8;
   }
 
-  :root[data-theme="monochrome"] .status-time,
-  body[data-theme="monochrome"] .status-time {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status-time,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status-time {
     color: #bdbdbd;
   }
 
-  :root[data-theme="christmas"] .status-warning,
-  body[data-theme="christmas"] .status-warning {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status-warning,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status-warning {
     background: #2a1b19;
   }
 
-  :root[data-theme="sky-pink"] .status-warning,
-  body[data-theme="sky-pink"] .status-warning {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-warning,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-warning {
     background: #1e1a24;
   }
 
-  :root[data-theme="christmas"] .status-warning-text,
-  body[data-theme="christmas"] .status-warning-text {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status-warning-text,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status-warning-text {
     color: #cf8c8c;
   }
 
-  :root[data-theme="sky-pink"] .status-warning-text,
-  body[data-theme="sky-pink"] .status-warning-text {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-warning-text,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-warning-text {
     color: #d9a3bd;
   }
 
-  :root[data-theme="monochrome"] .status-warning,
-  body[data-theme="monochrome"] .status-warning {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status-warning,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status-warning {
     background: #181818;
   }
 
-  :root[data-theme="monochrome"] .status-warning-text,
-  body[data-theme="monochrome"] .status-warning-text {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status-warning-text,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status-warning-text {
     color: #d6d6d6;
   }
 
-  .status p {
+  :root:not([data-color-scheme="light"]) .status p,
+  body:not([data-color-scheme="light"]) .status p {
     color: #f0e7dc;
   }
 
-  .status-time {
+  :root:not([data-color-scheme="light"]) .status-time,
+  body:not([data-color-scheme="light"]) .status-time {
     color: #c4b6a6;
   }
 
-  .status-warning {
+  :root:not([data-color-scheme="light"]) .status-warning,
+  body:not([data-color-scheme="light"]) .status-warning {
     background: #2a241f;
   }
 
-  .status-warning-text {
+  :root:not([data-color-scheme="light"]) .status-warning-text,
+  body:not([data-color-scheme="light"]) .status-warning-text {
     color: #c4b6a6;
   }
 
-  .replying {
+  :root:not([data-color-scheme="light"]) .replying,
+  body:not([data-color-scheme="light"]) .replying {
     background: #2a241f;
   }
 
-  .account-form input,
-  .compose-form textarea,
-  .compose-actions select,
-  .settings-item select {
+  :root:not([data-color-scheme="light"]) .account-form input,
+  body:not([data-color-scheme="light"]) .account-form input,
+  :root:not([data-color-scheme="light"]) .compose-form textarea,
+  body:not([data-color-scheme="light"]) .compose-form textarea,
+  :root:not([data-color-scheme="light"]) .compose-actions select,
+  body:not([data-color-scheme="light"]) .compose-actions select,
+  :root:not([data-color-scheme="light"]) .settings-item select,
+  body:not([data-color-scheme="light"]) .settings-item select {
     background: #151310;
     border: 1px solid #3a312a;
     color: #f0e7dc;
   }
 
-  :root[data-theme="christmas"] .account-form input,
-  body[data-theme="christmas"] .account-form input,
-  :root[data-theme="christmas"] .compose-form textarea,
-  body[data-theme="christmas"] .compose-form textarea,
-  :root[data-theme="christmas"] .compose-actions select,
-  body[data-theme="christmas"] .compose-actions select,
-  :root[data-theme="christmas"] .settings-item select,
-  body[data-theme="christmas"] .settings-item select {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-form input,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-form input,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-form textarea,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-form textarea,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-actions select,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-actions select,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .settings-item select,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .settings-item select {
     background: #1a100f;
     border: 1px solid #3b2624;
     color: #f7e7df;
   }
 
-  :root[data-theme="sky-pink"] .account-form input,
-  body[data-theme="sky-pink"] .account-form input,
-  :root[data-theme="sky-pink"] .compose-form textarea,
-  body[data-theme="sky-pink"] .compose-form textarea,
-  :root[data-theme="sky-pink"] .compose-actions select,
-  body[data-theme="sky-pink"] .compose-actions select,
-  :root[data-theme="sky-pink"] .settings-item select,
-  body[data-theme="sky-pink"] .settings-item select {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-form input,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-form input,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-form textarea,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-form textarea,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-actions select,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-actions select,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-item select,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-item select {
     background: #181e2a;
     border: 1px solid #2e3b50;
     color: #eff1f7;
   }
 
-  :root[data-theme="christmas"] .account-form input::placeholder,
-  body[data-theme="christmas"] .account-form input::placeholder,
-  :root[data-theme="christmas"] .compose-form textarea::placeholder,
-  body[data-theme="christmas"] .compose-form textarea::placeholder {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-form input::placeholder,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-form input::placeholder,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-form textarea::placeholder,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-form textarea::placeholder {
     color: #c59a9a;
   }
 
-  :root[data-theme="sky-pink"] .account-form input::placeholder,
-  body[data-theme="sky-pink"] .account-form input::placeholder,
-  :root[data-theme="sky-pink"] .compose-form textarea::placeholder,
-  body[data-theme="sky-pink"] .compose-form textarea::placeholder {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-form input::placeholder,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-form input::placeholder,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-form textarea::placeholder,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-form textarea::placeholder {
     color: #aeb7c6;
   }
 
-  :root[data-theme="monochrome"] .account-form input,
-  body[data-theme="monochrome"] .account-form input,
-  :root[data-theme="monochrome"] .compose-form textarea,
-  body[data-theme="monochrome"] .compose-form textarea,
-  :root[data-theme="monochrome"] .compose-actions select,
-  body[data-theme="monochrome"] .compose-actions select,
-  :root[data-theme="monochrome"] .settings-item select,
-  body[data-theme="monochrome"] .settings-item select {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-form input,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-form input,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-form textarea,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-form textarea,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-actions select,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-actions select,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .settings-item select,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .settings-item select {
     background: #101010;
     border: 1px solid #3a3a3a;
     color: #f0f0f0;
   }
 
-  :root[data-theme="monochrome"] .account-form input::placeholder,
-  body[data-theme="monochrome"] .account-form input::placeholder,
-  :root[data-theme="monochrome"] .compose-form textarea::placeholder,
-  body[data-theme="monochrome"] .compose-form textarea::placeholder {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-form input::placeholder,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-form input::placeholder,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-form textarea::placeholder,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-form textarea::placeholder {
     color: #8a8a8a;
   }
 
-  .account-form-divider {
+  :root:not([data-color-scheme="light"]) .account-form-divider,
+  body:not([data-color-scheme="light"]) .account-form-divider {
     border-top: 1px dashed #3b342d;
   }
 
-  .account-form input::placeholder,
-  .compose-form textarea::placeholder {
+  :root:not([data-color-scheme="light"]) .account-form input::placeholder,
+  body:not([data-color-scheme="light"]) .account-form input::placeholder,
+  :root:not([data-color-scheme="light"]) .compose-form textarea::placeholder,
+  body:not([data-color-scheme="light"]) .compose-form textarea::placeholder {
     color: #9b8e80;
   }
 
-  button {
+  :root:not([data-color-scheme="light"]) button,
+  body:not([data-color-scheme="light"]) button {
     background: #4a6cb6;
     color: #edf3ff;
   }
 
-  .settings-danger-button {
+  :root:not([data-color-scheme="light"]) .settings-danger-button,
+  body:not([data-color-scheme="light"]) .settings-danger-button {
     background: #b5463b;
     color: #fff6f0;
   }
 
-  :root[data-theme="christmas"] button,
-  body[data-theme="christmas"] button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] button {
     background: #8f2f2f;
     color: #fff1f1;
   }
 
-  :root[data-theme="christmas"] .settings-danger-button,
-  body[data-theme="christmas"] .settings-danger-button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .settings-danger-button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .settings-danger-button {
     background: #a54343;
     color: #fff1f1;
   }
 
-  :root[data-theme="sky-pink"] button,
-  body[data-theme="sky-pink"] button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] button {
     background: #7db4f0;
     color: #0f1c2a;
   }
 
-  :root[data-theme="sky-pink"] .settings-danger-button,
-  body[data-theme="sky-pink"] .settings-danger-button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-danger-button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-danger-button {
     background: #d97183;
     color: #fff4f6;
   }
 
-  :root[data-theme="monochrome"] button,
-  body[data-theme="monochrome"] button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] button {
     background: #e6e6e6;
     color: #111111;
   }
 
-  :root[data-theme="monochrome"] .settings-danger-button,
-  body[data-theme="monochrome"] .settings-danger-button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .settings-danger-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .settings-danger-button {
     background: #d32f2f;
     color: #fff5f5;
   }
 
-  button.is-active {
+  :root:not([data-color-scheme="light"]) button.is-active,
+  body:not([data-color-scheme="light"]) button.is-active {
     background: #8fa6cf;
     color: #1d2638;
   }
 
-  :root[data-theme="christmas"] button.is-active,
-  body[data-theme="christmas"] button.is-active {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] button.is-active,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] button.is-active {
     background: #b07a3b;
     color: #2b1a10;
   }
 
-  :root[data-theme="sky-pink"] button.is-active,
-  body[data-theme="sky-pink"] button.is-active {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] button.is-active,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] button.is-active {
     background: #f0a6c8;
     color: #2a1620;
   }
 
-  :root[data-theme="monochrome"] button.is-active,
-  body[data-theme="monochrome"] button.is-active {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] button.is-active,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] button.is-active {
     background: #bdbdbd;
     color: #111111;
   }
 
-  button.ghost {
+  :root:not([data-color-scheme="light"]) button.ghost,
+  body:not([data-color-scheme="light"]) button.ghost {
     color: #8fa6cf;
   }
 
-  :root[data-theme="christmas"] button.ghost,
-  body[data-theme="christmas"] button.ghost {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] button.ghost,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] button.ghost {
     color: #cf8c8c;
   }
 
-  :root[data-theme="sky-pink"] button.ghost,
-  body[data-theme="sky-pink"] button.ghost {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] button.ghost,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] button.ghost {
     color: #f0a6c8;
   }
 
-  :root[data-theme="monochrome"] button.ghost,
-  body[data-theme="monochrome"] button.ghost {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] button.ghost,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] button.ghost {
     color: #f0f0f0;
   }
 
-  .text-link {
+  :root:not([data-color-scheme="light"]) .text-link,
+  body:not([data-color-scheme="light"]) .text-link {
     color: #8fa6cf;
     background: none;
   }
 
-  :root[data-theme="christmas"] .text-link,
-  body[data-theme="christmas"] .text-link {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .text-link,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .text-link {
     color: #cf8c8c;
     background: none;
   }
 
-  :root[data-theme="sky-pink"] .text-link,
-  body[data-theme="sky-pink"] .text-link {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .text-link,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .text-link {
     color: #f0a6c8;
     background: none;
   }
 
-  :root[data-theme="monochrome"] .text-link,
-  body[data-theme="monochrome"] .text-link {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .text-link,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .text-link {
     color: #f0f0f0;
     background: none;
   }
 
-  .account-add-button {
+  :root:not([data-color-scheme="light"]) .account-add-button,
+  body:not([data-color-scheme="light"]) .account-add-button {
     background: #4a6cb6;
     color: #edf3ff;
   }
 
-  :root[data-theme="christmas"] .account-add-button,
-  body[data-theme="christmas"] .account-add-button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-add-button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-add-button {
     background: #2e6b4f;
     color: #f4fff7;
   }
 
-  :root[data-theme="sky-pink"] .account-add-button,
-  body[data-theme="sky-pink"] .account-add-button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-add-button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-add-button {
     background: #7db4f0;
     color: #0f1c2a;
   }
 
-  :root[data-theme="monochrome"] .account-add-button,
-  body[data-theme="monochrome"] .account-add-button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-add-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-add-button {
     background: #e6e6e6;
     color: #111111;
   }
 
-  .account-add-panel {
+  :root:not([data-color-scheme="light"]) .account-add-panel,
+  body:not([data-color-scheme="light"]) .account-add-panel {
     background: rgba(23, 21, 18, 0.88);
     color: #f0e7dc;
     border: 1px solid #3b342d;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  :root[data-theme="christmas"] .account-add-panel,
-  body[data-theme="christmas"] .account-add-panel {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-add-panel,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-add-panel {
     background: rgba(26, 16, 15, 0.88);
     color: #f7e7df;
     border: 1px solid #3b2624;
     box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
   }
 
-  :root[data-theme="sky-pink"] .account-add-panel,
-  body[data-theme="sky-pink"] .account-add-panel {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-add-panel,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-add-panel {
     background: rgba(24, 30, 42, 0.9);
     color: #eff1f7;
     border: 1px solid #2e3b50;
     box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
   }
 
-  :root[data-theme="monochrome"] .account-add-panel,
-  body[data-theme="monochrome"] .account-add-panel {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-add-panel,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-add-panel {
     background: rgba(16, 16, 16, 0.88);
     color: #f0f0f0;
     border: 1px solid #3a3a3a;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  .section-menu-panel {
+  :root:not([data-color-scheme="light"]) .section-menu-panel,
+  body:not([data-color-scheme="light"]) .section-menu-panel {
     background: rgba(23, 21, 18, 0.88);
     color: #f0e7dc;
     border: 1px solid #3b342d;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  .section-menu-panel button {
+  :root:not([data-color-scheme="light"]) .section-menu-panel button,
+  body:not([data-color-scheme="light"]) .section-menu-panel button {
     color: #f0e7dc;
   }
 
-  .section-menu-panel .danger {
+  :root:not([data-color-scheme="light"]) .section-menu-panel .danger,
+  body:not([data-color-scheme="light"]) .section-menu-panel .danger {
     color: #e07a6d;
   }
 
-  :root[data-theme="monochrome"] .section-menu-panel .danger,
-  body[data-theme="monochrome"] .section-menu-panel .danger {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .section-menu-panel .danger,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .section-menu-panel .danger {
     color: #ff8a8a;
   }
 
-  :root[data-theme="christmas"] .section-menu-panel,
-  body[data-theme="christmas"] .section-menu-panel {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .section-menu-panel,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .section-menu-panel {
     background: rgba(26, 16, 15, 0.88);
     color: #f7e7df;
     border: 1px solid #3b2624;
     box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
   }
 
-  :root[data-theme="christmas"] .section-menu-panel button,
-  body[data-theme="christmas"] .section-menu-panel button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .section-menu-panel button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .section-menu-panel button {
     color: #f7e7df;
   }
 
-  :root[data-theme="sky-pink"] .section-menu-panel,
-  body[data-theme="sky-pink"] .section-menu-panel {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .section-menu-panel,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .section-menu-panel {
     background: rgba(24, 30, 42, 0.9);
     color: #eff1f7;
     border: 1px solid #2e3b50;
     box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
   }
 
-  :root[data-theme="sky-pink"] .section-menu-panel button,
-  body[data-theme="sky-pink"] .section-menu-panel button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .section-menu-panel button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .section-menu-panel button {
     color: #eff1f7;
   }
 
-  :root[data-theme="monochrome"] .section-menu-panel,
-  body[data-theme="monochrome"] .section-menu-panel {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .section-menu-panel,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .section-menu-panel {
     background: rgba(16, 16, 16, 0.88);
     color: #f0f0f0;
     border: 1px solid #3a3a3a;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  :root[data-theme="monochrome"] .section-menu-panel button,
-  body[data-theme="monochrome"] .section-menu-panel button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .section-menu-panel button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .section-menu-panel button {
     color: #f0f0f0;
   }
 
-  .account-selector-summary {
+  :root:not([data-color-scheme="light"]) .account-selector-summary,
+  body:not([data-color-scheme="light"]) .account-selector-summary {
     background: #171512;
     border: 1px solid #3b342d;
   }
 
-  .account-selector-dropdown {
+  :root:not([data-color-scheme="light"]) .account-selector-dropdown,
+  body:not([data-color-scheme="light"]) .account-selector-dropdown {
     background: rgba(23, 21, 18, 0.88);
     border: 1px solid #3b342d;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  .account-selector-placeholder,
-  .account-selector-caret {
+  :root:not([data-color-scheme="light"]) .account-selector-placeholder,
+  body:not([data-color-scheme="light"]) .account-selector-placeholder,
+  :root:not([data-color-scheme="light"]) .account-selector-caret,
+  body:not([data-color-scheme="light"]) .account-selector-caret {
     color: #c4b6a6;
   }
 
-  :root[data-theme="christmas"] .account-selector-summary,
-  body[data-theme="christmas"] .account-selector-summary {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-summary,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-summary {
     background: #1a100f;
     border: 1px solid #3b2624;
   }
 
-  :root[data-theme="christmas"] .account-selector-dropdown,
-  body[data-theme="christmas"] .account-selector-dropdown {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-dropdown,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-dropdown {
     background: rgba(26, 16, 15, 0.88);
     border: 1px solid #3b2624;
     box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
   }
 
-  :root[data-theme="sky-pink"] .account-selector-summary,
-  body[data-theme="sky-pink"] .account-selector-summary {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-summary,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-summary {
     background: #181e2a;
     border: 1px solid #2e3b50;
   }
 
-  :root[data-theme="sky-pink"] .account-selector-dropdown,
-  body[data-theme="sky-pink"] .account-selector-dropdown {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-dropdown,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-dropdown {
     background: rgba(24, 30, 42, 0.9);
     border: 1px solid #2e3b50;
     box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
   }
 
-  :root[data-theme="monochrome"] .account-selector-summary,
-  body[data-theme="monochrome"] .account-selector-summary {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-summary,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-summary {
     background: #101010;
     border: 1px solid #3a3a3a;
   }
 
-  :root[data-theme="monochrome"] .account-selector-dropdown,
-  body[data-theme="monochrome"] .account-selector-dropdown {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-dropdown,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-dropdown {
     background: rgba(16, 16, 16, 0.88);
     border: 1px solid #3a3a3a;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   }
 
-  :root[data-theme="christmas"] .account-selector-placeholder,
-  body[data-theme="christmas"] .account-selector-placeholder,
-  :root[data-theme="christmas"] .account-selector-caret,
-  body[data-theme="christmas"] .account-selector-caret {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-placeholder,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-placeholder,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-caret,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .account-selector-caret {
     color: #cf8c8c;
   }
 
-  :root[data-theme="sky-pink"] .account-selector-placeholder,
-  body[data-theme="sky-pink"] .account-selector-placeholder,
-  :root[data-theme="sky-pink"] .account-selector-caret,
-  body[data-theme="sky-pink"] .account-selector-caret {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-placeholder,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-placeholder,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-caret,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .account-selector-caret {
     color: #f0a6c8;
   }
 
-  :root[data-theme="monochrome"] .account-selector-summary .account-text,
-  body[data-theme="monochrome"] .account-selector-summary .account-text,
-  :root[data-theme="monochrome"] .account-selector-dropdown .account-text,
-  body[data-theme="monochrome"] .account-selector-dropdown .account-text {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-summary .account-text,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-summary .account-text,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-dropdown .account-text,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-dropdown .account-text {
     color: #f0f0f0;
   }
 
-  :root[data-theme="monochrome"] .account-selector-placeholder,
-  body[data-theme="monochrome"] .account-selector-placeholder,
-  :root[data-theme="monochrome"] .account-selector-caret,
-  body[data-theme="monochrome"] .account-selector-caret {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-placeholder,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-placeholder,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-caret,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-selector-caret {
     color: #cfcfcf;
   }
 
-  .sidebar-description,
-  .oss-list {
+  :root:not([data-color-scheme="light"]) .sidebar-description,
+  body:not([data-color-scheme="light"]) .sidebar-description,
+  :root:not([data-color-scheme="light"]) .oss-list,
+  body:not([data-color-scheme="light"]) .oss-list {
     color: #c4b6a6;
   }
 
-  .sidebar-description a {
+  :root:not([data-color-scheme="light"]) .sidebar-description a,
+  body:not([data-color-scheme="light"]) .sidebar-description a {
     color: #8fa6cf;
   }
 
-  .sidebar-links a {
+  :root:not([data-color-scheme="light"]) .sidebar-links a,
+  body:not([data-color-scheme="light"]) .sidebar-links a {
     color: #d7cbbd;
   }
 
-  :root[data-theme="monochrome"] .sidebar-description,
-  body[data-theme="monochrome"] .sidebar-description,
-  :root[data-theme="monochrome"] .oss-list,
-  body[data-theme="monochrome"] .oss-list {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .sidebar-description,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .sidebar-description,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .oss-list,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .oss-list {
     color: #d6d6d6;
   }
 
-  :root[data-theme="sky-pink"] .sidebar-description,
-  body[data-theme="sky-pink"] .sidebar-description,
-  :root[data-theme="sky-pink"] .oss-list,
-  body[data-theme="sky-pink"] .oss-list {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-description,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-description,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .oss-list,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .oss-list {
     color: #d7ddea;
   }
 
-  :root[data-theme="monochrome"] .sidebar-description a,
-  body[data-theme="monochrome"] .sidebar-description a,
-  :root[data-theme="monochrome"] .sidebar-links a,
-  body[data-theme="monochrome"] .sidebar-links a {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .sidebar-description a,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .sidebar-description a,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .sidebar-links a,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .sidebar-links a {
     color: #f0f0f0;
   }
 
-  :root[data-theme="christmas"] .sidebar-links a,
-  body[data-theme="christmas"] .sidebar-links a {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .sidebar-links a,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .sidebar-links a {
     color: #9cc7ab;
   }
 
-  :root[data-theme="sky-pink"] .sidebar-description a,
-  body[data-theme="sky-pink"] .sidebar-description a {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-description a,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-description a {
     color: #9dbef4;
   }
 
-  :root[data-theme="sky-pink"] .sidebar-links a,
-  body[data-theme="sky-pink"] .sidebar-links a {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-links a,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-links a {
     color: #f0a6c8;
   }
 
-  .sidebar-divider {
+  :root:not([data-color-scheme="light"]) .sidebar-divider,
+  body:not([data-color-scheme="light"]) .sidebar-divider {
     background: #3b342d;
   }
 
-  :root[data-theme="christmas"] .sidebar-divider,
-  body[data-theme="christmas"] .sidebar-divider {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .sidebar-divider,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .sidebar-divider {
     background: #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .sidebar-divider,
-  body[data-theme="sky-pink"] .sidebar-divider {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-divider,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .sidebar-divider {
     background: #2e3b50;
   }
 
-  .settings-item {
+  :root:not([data-color-scheme="light"]) .settings-item,
+  body:not([data-color-scheme="light"]) .settings-item {
     border-top: 1px solid #3b342d;
   }
 
-  .settings-item p {
+  :root:not([data-color-scheme="light"]) .settings-item p,
+  body:not([data-color-scheme="light"]) .settings-item p {
     color: #c4b6a6;
   }
 
-  :root[data-theme="christmas"] .settings-item,
-  body[data-theme="christmas"] .settings-item {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .settings-item,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .settings-item {
     border-top: 1px solid #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .settings-item,
-  body[data-theme="sky-pink"] .settings-item {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-item,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-item {
     border-top: 1px solid #2e3b50;
   }
 
-  :root[data-theme="sky-pink"] .settings-item p,
-  body[data-theme="sky-pink"] .settings-item p {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-item p,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .settings-item p {
     color: #d7ddea;
   }
 
-  :root[data-theme="monochrome"] .settings-item p,
-  body[data-theme="monochrome"] .settings-item p {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .settings-item p,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .settings-item p {
     color: #d6d6d6;
   }
 
-  .settings-modal-backdrop {
+  :root:not([data-color-scheme="light"]) .settings-modal-backdrop,
+  body:not([data-color-scheme="light"]) .settings-modal-backdrop {
     background: rgba(8, 7, 6, 0.7);
   }
 
-  .back-link {
+  :root:not([data-color-scheme="light"]) .back-link,
+  body:not([data-color-scheme="light"]) .back-link {
     color: #d7cbbd;
   }
 
-  .boosted-by {
+  :root:not([data-color-scheme="light"]) .boosted-by,
+  body:not([data-color-scheme="light"]) .boosted-by {
     color: #c4b6a6;
   }
 
-  :root[data-theme="christmas"] .boosted-by,
-  body[data-theme="christmas"] .boosted-by {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .boosted-by,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .boosted-by {
     color: #9cc7ab;
   }
 
-  :root[data-theme="sky-pink"] .boosted-by,
-  body[data-theme="sky-pink"] .boosted-by {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .boosted-by,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .boosted-by {
     color: #9dbef4;
   }
 
-  :root[data-theme="monochrome"] .boosted-by,
-  body[data-theme="monochrome"] .boosted-by {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .boosted-by,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .boosted-by {
     color: #bdbdbd;
   }
 
-  .reply-info {
+  :root:not([data-color-scheme="light"]) .reply-info,
+  body:not([data-color-scheme="light"]) .reply-info {
     color: #c4b6a6;
   }
 
-  :root[data-theme="christmas"] .reply-info,
-  body[data-theme="christmas"] .reply-info {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .reply-info,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .reply-info {
     color: #cf8c8c;
   }
 
-  :root[data-theme="sky-pink"] .reply-info,
-  body[data-theme="sky-pink"] .reply-info {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .reply-info,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .reply-info {
     color: #f0a6c8;
   }
 
-  :root[data-theme="monochrome"] .reply-info,
-  body[data-theme="monochrome"] .reply-info {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .reply-info,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .reply-info {
     color: #bdbdbd;
   }
 
-  .status-reaction {
+  :root:not([data-color-scheme="light"]) .status-reaction,
+  body:not([data-color-scheme="light"]) .status-reaction {
     color: #e9dfd2;
     border-color: #5a4f45;
   }
 
-  :root[data-theme="christmas"] .status-reaction,
-  body[data-theme="christmas"] .status-reaction {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status-reaction,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status-reaction {
     color: #f7e7df;
     border-color: #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .status-reaction,
-  body[data-theme="sky-pink"] .status-reaction {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-reaction,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-reaction {
     color: #eff1f7;
     border-color: #2e3b50;
   }
 
-  :root[data-theme="monochrome"] .status-reaction,
-  body[data-theme="monochrome"] .status-reaction {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status-reaction,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status-reaction {
     color: #d6d6d6;
     border-color: #3a3a3a;
   }
 
-  .status-reaction.is-active {
+  :root:not([data-color-scheme="light"]) .status-reaction.is-active,
+  body:not([data-color-scheme="light"]) .status-reaction.is-active {
     background: #2c2722;
     border-color: #6f5c47;
     color: #fff7ec;
   }
 
-  :root[data-theme="christmas"] .status-reaction.is-active,
-  body[data-theme="christmas"] .status-reaction.is-active {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .status-reaction.is-active,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .status-reaction.is-active {
     background: #2a1b19;
     border-color: #3b2624;
     color: #fff1f1;
   }
 
-  :root[data-theme="sky-pink"] .status-reaction.is-active,
-  body[data-theme="sky-pink"] .status-reaction.is-active {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-reaction.is-active,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .status-reaction.is-active {
     background: #212a3a;
     border-color: #2e3b50;
     color: #f2f5fb;
   }
 
-  :root[data-theme="monochrome"] .status-reaction.is-active,
-  body[data-theme="monochrome"] .status-reaction.is-active {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .status-reaction.is-active,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .status-reaction.is-active {
     background: #1a1a1a;
     border-color: #4a4a4a;
     color: #f5f5f5;
   }
 
-  .status-header {
+  :root:not([data-color-scheme="light"]) .status-header,
+  body:not([data-color-scheme="light"]) .status-header {
     color: #c4b6a6;
   }
 
-  .account-handle {
+  :root:not([data-color-scheme="light"]) .account-handle,
+  body:not([data-color-scheme="light"]) .account-handle {
     color: #c4b6a6;
   }
 
-  :root[data-theme="monochrome"] .account-handle,
-  body[data-theme="monochrome"] .account-handle {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .account-handle,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .account-handle {
     color: #bdbdbd;
   }
 
-  .account-avatar {
+  :root:not([data-color-scheme="light"]) .account-avatar,
+  body:not([data-color-scheme="light"]) .account-avatar {
     background: #221f1b;
     border: 1px solid #3b342d;
   }
 
-  .status-avatar {
+  :root:not([data-color-scheme="light"]) .status-avatar,
+  body:not([data-color-scheme="light"]) .status-avatar {
     background: #221f1b;
     border: 1px solid #3b342d;
   }
 
-  .account-avatar-fallback {
+  :root:not([data-color-scheme="light"]) .account-avatar-fallback,
+  body:not([data-color-scheme="light"]) .account-avatar-fallback {
     background: #6c5c4b;
   }
 
-  .status-avatar-fallback {
+  :root:not([data-color-scheme="light"]) .status-avatar-fallback,
+  body:not([data-color-scheme="light"]) .status-avatar-fallback {
     background: #6c5c4b;
   }
 
-  .attachment-thumb {
+  :root:not([data-color-scheme="light"]) .attachment-thumb,
+  body:not([data-color-scheme="light"]) .attachment-thumb {
     border: 1px solid #3b342d;
     background: #171512;
   }
 
-  .file-button {
+  :root:not([data-color-scheme="light"]) .file-button,
+  body:not([data-color-scheme="light"]) .file-button {
     background: #2c3b59;
     color: #e1e7f4;
   }
 
-  .compose-icon-button {
+  :root:not([data-color-scheme="light"]) .compose-icon-button,
+  body:not([data-color-scheme="light"]) .compose-icon-button {
     background: #2c3b59;
     color: #e1e7f4;
     border-color: #3b342d;
   }
 
-  :root[data-theme="christmas"] .file-button,
-  body[data-theme="christmas"] .file-button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .file-button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .file-button {
     background: #2a1b19;
     color: #f7e7df;
   }
 
-  :root[data-theme="christmas"] .compose-icon-button,
-  body[data-theme="christmas"] .compose-icon-button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-icon-button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-icon-button {
     background: #2a1b19;
     color: #f7e7df;
     border-color: #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .file-button,
-  body[data-theme="sky-pink"] .file-button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .file-button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .file-button {
     background: #223047;
     color: #d7e7fb;
   }
 
-  :root[data-theme="sky-pink"] .compose-icon-button,
-  body[data-theme="sky-pink"] .compose-icon-button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-icon-button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-icon-button {
     background: #223047;
     color: #d7e7fb;
     border-color: #2e3b50;
   }
 
-  :root[data-theme="monochrome"] .file-button,
-  body[data-theme="monochrome"] .file-button,
-  :root[data-theme="monochrome"] .compose-icon-button,
-  body[data-theme="monochrome"] .compose-icon-button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .file-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .file-button,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-icon-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-icon-button {
     background: #2a2a2a;
     color: #f0f0f0;
     border-color: #4a4a4a;
   }
 
-  .compose-emoji-panel {
+  :root:not([data-color-scheme="light"]) .compose-emoji-panel,
+  body:not([data-color-scheme="light"]) .compose-emoji-panel {
     background: #1b1916;
     border-color: #3b342d;
   }
 
-  :root[data-theme="christmas"] .compose-emoji-panel,
-  body[data-theme="christmas"] .compose-emoji-panel {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-panel,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-panel {
     background: #201412;
     border-color: #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .compose-emoji-panel,
-  body[data-theme="sky-pink"] .compose-emoji-panel {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-panel,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-panel {
     background: #181e2a;
     border-color: #2e3b50;
   }
 
-  :root[data-theme="monochrome"] .compose-emoji-panel,
-  body[data-theme="monochrome"] .compose-emoji-panel {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-panel,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-panel {
     background: #101010;
     border-color: #3a3a3a;
   }
 
-  .compose-emoji-category-toggle {
+  :root:not([data-color-scheme="light"]) .compose-emoji-category-toggle,
+  body:not([data-color-scheme="light"]) .compose-emoji-category-toggle {
     background: #2a2622;
     color: #f0e7dc;
     border-color: #3b342d;
   }
 
-  :root[data-theme="christmas"] .compose-emoji-category-toggle,
-  body[data-theme="christmas"] .compose-emoji-category-toggle {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-category-toggle,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-category-toggle {
     background: #2a1b19;
     color: #f7e7df;
     border-color: #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .compose-emoji-category-toggle,
-  body[data-theme="sky-pink"] .compose-emoji-category-toggle {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-category-toggle,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-category-toggle {
     background: #223047;
     color: #eff1f7;
     border-color: #2e3b50;
   }
 
-  :root[data-theme="monochrome"] .compose-emoji-category-toggle,
-  body[data-theme="monochrome"] .compose-emoji-category-toggle {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-category-toggle,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-category-toggle {
     background: #1a1a1a;
     color: #f5f5f5;
     border-color: #3a3a3a;
   }
 
-  .compose-emoji-count {
+  :root:not([data-color-scheme="light"]) .compose-emoji-count,
+  body:not([data-color-scheme="light"]) .compose-emoji-count {
     background: #2c3b59;
     color: #e1e7f4;
   }
 
-  :root[data-theme="christmas"] .compose-emoji-count,
-  body[data-theme="christmas"] .compose-emoji-count {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-count,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-count {
     background: #3b2624;
     color: #f7e7df;
   }
 
-  :root[data-theme="sky-pink"] .compose-emoji-count,
-  body[data-theme="sky-pink"] .compose-emoji-count {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-count,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-count {
     background: #344760;
     color: #f2f5fb;
   }
 
-  :root[data-theme="monochrome"] .compose-emoji-count,
-  body[data-theme="monochrome"] .compose-emoji-count {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-count,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-count {
     background: #2a2a2a;
     color: #f0f0f0;
   }
 
-  .compose-emoji-button {
+  :root:not([data-color-scheme="light"]) .compose-emoji-button,
+  body:not([data-color-scheme="light"]) .compose-emoji-button {
     background: #221f1b;
     border-color: #3b342d;
   }
 
-  :root[data-theme="christmas"] .compose-emoji-button,
-  body[data-theme="christmas"] .compose-emoji-button {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-button,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-button {
     background: #1a100f;
     border-color: #3b2624;
   }
 
-  :root[data-theme="sky-pink"] .compose-emoji-button,
-  body[data-theme="sky-pink"] .compose-emoji-button {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-button,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-button {
     background: #223047;
     border-color: #2e3b50;
   }
 
-  :root[data-theme="monochrome"] .compose-emoji-button,
-  body[data-theme="monochrome"] .compose-emoji-button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-button {
     background: #1a1a1a;
     border-color: #3a3a3a;
   }
 
-  .compose-emoji-empty {
+  :root:not([data-color-scheme="light"]) .compose-emoji-empty,
+  body:not([data-color-scheme="light"]) .compose-emoji-empty {
     color: #c4b6a6;
   }
 
-  :root[data-theme="christmas"] .compose-emoji-empty,
-  body[data-theme="christmas"] .compose-emoji-empty {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-empty,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .compose-emoji-empty {
     color: #cf8c8c;
   }
 
-  :root[data-theme="sky-pink"] .compose-emoji-empty,
-  body[data-theme="sky-pink"] .compose-emoji-empty {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-empty,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .compose-emoji-empty {
     color: #b7c2d2;
   }
 
-  :root[data-theme="monochrome"] .compose-emoji-empty,
-  body[data-theme="monochrome"] .compose-emoji-empty {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-empty,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .compose-emoji-empty {
     color: #bdbdbd;
   }
 
-  .link-preview {
+  :root:not([data-color-scheme="light"]) .link-preview,
+  body:not([data-color-scheme="light"]) .link-preview {
     border: 1px solid #3b342d;
     background: #171512;
   }
 
-  :root[data-theme="christmas"] .link-preview,
-  body[data-theme="christmas"] .link-preview {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview {
     border: 1px solid #3b2624;
     background: #1a100f;
   }
 
-  :root[data-theme="sky-pink"] .link-preview,
-  body[data-theme="sky-pink"] .link-preview {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview {
     border: 1px solid #2e3b50;
     background: #181e2a;
   }
 
-  :root[data-theme="monochrome"] .link-preview,
-  body[data-theme="monochrome"] .link-preview {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview {
     border: 1px solid #3a3a3a;
     background: #101010;
   }
 
-  .link-preview-body {
+  :root:not([data-color-scheme="light"]) .link-preview-body,
+  body:not([data-color-scheme="light"]) .link-preview-body {
     color: #c4b6a6;
   }
 
-  :root[data-theme="christmas"] .link-preview-body,
-  body[data-theme="christmas"] .link-preview-body {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview-body,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview-body {
     color: #e4b9b9;
   }
 
-  :root[data-theme="sky-pink"] .link-preview-body,
-  body[data-theme="sky-pink"] .link-preview-body {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview-body,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview-body {
     color: #d7ddea;
   }
 
-  :root[data-theme="monochrome"] .link-preview-body,
-  body[data-theme="monochrome"] .link-preview-body {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview-body,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview-body {
     color: #d6d6d6;
   }
 
-  .link-preview-body strong {
+  :root:not([data-color-scheme="light"]) .link-preview-body strong,
+  body:not([data-color-scheme="light"]) .link-preview-body strong {
     color: #f0e7dc;
   }
 
-  :root[data-theme="christmas"] .link-preview-body strong,
-  body[data-theme="christmas"] .link-preview-body strong {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview-body strong,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview-body strong {
     color: #f4d7d7;
   }
 
-  :root[data-theme="sky-pink"] .link-preview-body strong,
-  body[data-theme="sky-pink"] .link-preview-body strong {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview-body strong,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview-body strong {
     color: #f2f5fb;
   }
 
-  :root[data-theme="monochrome"] .link-preview-body strong,
-  body[data-theme="monochrome"] .link-preview-body strong {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview-body strong,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview-body strong {
     color: #f5f5f5;
   }
 
-  .link-preview-url {
+  :root:not([data-color-scheme="light"]) .link-preview-url,
+  body:not([data-color-scheme="light"]) .link-preview-url {
     color: #d7cbbd;
   }
 
-  :root[data-theme="christmas"] .link-preview-url,
-  body[data-theme="christmas"] .link-preview-url {
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview-url,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .link-preview-url {
     color: #9cc7ab;
   }
 
-  :root[data-theme="sky-pink"] .link-preview-url,
-  body[data-theme="sky-pink"] .link-preview-url {
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview-url,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .link-preview-url {
     color: #9dbef4;
   }
 
-  :root[data-theme="monochrome"] .link-preview-url,
-  body[data-theme="monochrome"] .link-preview-url {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview-url,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .link-preview-url {
     color: #bdbdbd;
   }
 
-  .readme-text {
+  :root:not([data-color-scheme="light"]) .readme-text,
+  body:not([data-color-scheme="light"]) .readme-text {
     color: #c4b6a6;
   }
 
-  .readme-text a {
+  :root:not([data-color-scheme="light"]) .readme-text a,
+  body:not([data-color-scheme="light"]) .readme-text a {
     color: #d7cbbd;
   }
 
-  .readme-text code,
-  .readme-text pre {
+  :root:not([data-color-scheme="light"]) .readme-text code,
+  body:not([data-color-scheme="light"]) .readme-text code,
+  :root:not([data-color-scheme="light"]) .readme-text pre,
+  body:not([data-color-scheme="light"]) .readme-text pre {
     background: #221f1b;
   }
 
-  .status-text a {
+  :root:not([data-color-scheme="light"]) .status-text a,
+  body:not([data-color-scheme="light"]) .status-text a {
     color: #d7cbbd;
   }
 
-  .image-modal-backdrop {
+  :root:not([data-color-scheme="light"]) .image-modal-backdrop,
+  body:not([data-color-scheme="light"]) .image-modal-backdrop {
     background: rgba(8, 7, 6, 0.8);
   }
 
-  .image-modal-content img {
+  :root:not([data-color-scheme="light"]) .image-modal-content img,
+  body:not([data-color-scheme="light"]) .image-modal-content img {
     border: 1px solid #2f2923;
     background: #0b0a09;
   }
 
-  .confirm-modal-content {
+  :root:not([data-color-scheme="light"]) .confirm-modal-content,
+  body:not([data-color-scheme="light"]) .confirm-modal-content {
     background: #171512;
     border: 1px solid #3b342d;
   }
 
-  .confirm-actions .delete-button {
+  :root:not([data-color-scheme="light"]) .confirm-actions .delete-button,
+  body:not([data-color-scheme="light"]) .confirm-actions .delete-button {
     color: #fffaf2;
   }
 
-  :root[data-theme="monochrome"] .confirm-actions .delete-button,
-  body[data-theme="monochrome"] .confirm-actions .delete-button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .confirm-actions .delete-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .confirm-actions .delete-button {
     color: #fff5f5;
   }
 
-  .confirm-status {
+  :root:not([data-color-scheme="light"]) .confirm-status,
+  body:not([data-color-scheme="light"]) .confirm-status {
     background: #171512;
     border: 1px solid #302822;
   }
 
-  .image-modal-delete {
+  :root:not([data-color-scheme="light"]) .image-modal-delete,
+  body:not([data-color-scheme="light"]) .image-modal-delete {
     background: #7a3a2a;
     color: #f5efe7;
   }
 
-  :root[data-theme="monochrome"] .image-modal-delete,
-  body[data-theme="monochrome"] .image-modal-delete {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .image-modal-delete,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .image-modal-delete {
     background: #c62828;
     color: #fff5f5;
   }
 
-  .delete-button {
+  :root:not([data-color-scheme="light"]) .delete-button,
+  body:not([data-color-scheme="light"]) .delete-button {
     background: #7a3a2a;
   }
 
-  :root[data-theme="monochrome"] .delete-button,
-  body[data-theme="monochrome"] .delete-button {
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .delete-button,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .delete-button {
     background: #c62828;
   }
 
-  .license {
+  :root:not([data-color-scheme="light"]) .license,
+  body:not([data-color-scheme="light"]) .license {
     background: #221f1b;
     border: 1px solid #3b342d;
     color: #f0e7dc;
   }
 }
+
+  :root[data-color-scheme="dark"] {
+    background: radial-gradient(circle at top left, #1d1b18, #12110f 55%, #0d0c0b);
+    color: #f0e7dc;
+    --scrollbar-thumb: var(--scrollbar-thumb-dark);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"],
+  body[data-color-scheme="dark"][data-theme="christmas"] {
+    background: radial-gradient(circle at top left, #2a1716, #1d1110 55%, #120b0a);
+    color: #f7e7df;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"],
+  body[data-color-scheme="dark"][data-theme="sky-pink"] {
+    background: radial-gradient(circle at top left, #1b2330, #191a26 55%, #101218);
+    color: #eff1f7;
+    --scrollbar-thumb: #5f6875;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"],
+  body[data-color-scheme="dark"][data-theme="monochrome"] {
+    background: radial-gradient(circle at top left, #0f0f0f, #080808 55%, #030303);
+    color: #f5f5f5;
+    --scrollbar-thumb: #616161;
+  }
+
+  :root[data-color-scheme="dark"] .overlay-backdrop,
+  body[data-color-scheme="dark"] .overlay-backdrop {
+    background: rgba(15, 13, 11, 0.4);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .overlay-backdrop,
+  body[data-color-scheme="dark"][data-theme="christmas"] .overlay-backdrop {
+    background: rgba(32, 16, 15, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .overlay-backdrop,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .overlay-backdrop {
+    background: rgba(88, 102, 138, 0.35);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .overlay-backdrop,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .overlay-backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  :root[data-color-scheme="dark"] .panel,
+  body[data-color-scheme="dark"] .panel {
+    background: #1b1916cc;
+    border: 1px solid #3b342d;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .panel,
+  body[data-color-scheme="dark"][data-theme="christmas"] .panel {
+    background: #201412cc;
+    border: 1px solid #4a2f2c;
+    box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .panel,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .panel {
+    background: #1a202dcc;
+    border: 1px solid #2e3b50;
+    box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .panel,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .panel {
+    background: #121212cc;
+    border: 1px solid #3a3a3a;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"] .timeline-column,
+  body[data-color-scheme="dark"] .timeline-column {
+    background: #171512;
+    border: 1px solid #302822;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 12px 24px rgba(0, 0, 0, 0.35);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .timeline-column,
+  body[data-color-scheme="dark"][data-theme="christmas"] .timeline-column {
+    background: #1a100f;
+    border: 1px solid #3b2624;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(64, 20, 20, 0.35);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .timeline-column,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .timeline-column {
+    background: #181e2a;
+    border: 1px solid #2e3b50;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(12, 18, 28, 0.35);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .timeline-column,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .timeline-column {
+    background: #101010;
+    border: 1px solid #3a3a3a;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 24px rgba(0, 0, 0, 0.35);
+  }
+
+  :root[data-color-scheme="dark"] .app-header p,
+  body[data-color-scheme="dark"] .app-header p,
+  :root[data-color-scheme="dark"] .status header,
+  body[data-color-scheme="dark"] .status header,
+  :root[data-color-scheme="dark"] .account-list .ghost,
+  body[data-color-scheme="dark"] .account-list .ghost,
+  :root[data-color-scheme="dark"] .attachments a,
+  body[data-color-scheme="dark"] .attachments a,
+  :root[data-color-scheme="dark"] .empty,
+  body[data-color-scheme="dark"] .empty,
+  :root[data-color-scheme="dark"] .hint,
+  body[data-color-scheme="dark"] .hint {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .app-header p,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .app-header p,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status header,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status header,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-list .ghost,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-list .ghost,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .attachments a,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .attachments a,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .empty,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .empty,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .hint,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .hint {
+    color: #d6d6d6;
+  }
+
+  :root[data-color-scheme="dark"] .status,
+  body[data-color-scheme="dark"] .status {
+    background: #171512;
+    border: 1px solid #302822;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status {
+    background: #1a100f;
+    border: 1px solid #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status {
+    background: #181e2a;
+    border: 1px solid #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status {
+    background: #101010;
+    border: 1px solid #3a3a3a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status header,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status header {
+    color: #e4b9b9;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status header strong,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status header strong {
+    color: #f4d7d7;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status header span,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status header span,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .time-link,
+  body[data-color-scheme="dark"][data-theme="christmas"] .time-link {
+    color: #9cc7ab;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status header,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status header {
+    color: #d7ddea;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status header strong,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status header strong {
+    color: #f2f5fb;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status header span,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status header span,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .time-link,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .time-link {
+    color: #f0a6c8;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status header,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status header {
+    color: #d6d6d6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status header strong,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status header strong {
+    color: #f5f5f5;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status header span,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status header span,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .time-link,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .time-link {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status-time,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status-time {
+    color: #9cc7ab;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status-time,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status-time {
+    color: #f0a6c8;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status-time,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status-time {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status-warning,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status-warning {
+    background: #2a1b19;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status-warning,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status-warning {
+    background: #1e1a24;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status-warning-text,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status-warning-text {
+    color: #cf8c8c;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status-warning-text,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status-warning-text {
+    color: #d9a3bd;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status-warning,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status-warning {
+    background: #181818;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status-warning-text,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status-warning-text {
+    color: #d6d6d6;
+  }
+
+  :root[data-color-scheme="dark"] .status p,
+  body[data-color-scheme="dark"] .status p {
+    color: #f0e7dc;
+  }
+
+  :root[data-color-scheme="dark"] .status-time,
+  body[data-color-scheme="dark"] .status-time {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"] .status-warning,
+  body[data-color-scheme="dark"] .status-warning {
+    background: #2a241f;
+  }
+
+  :root[data-color-scheme="dark"] .status-warning-text,
+  body[data-color-scheme="dark"] .status-warning-text {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"] .replying,
+  body[data-color-scheme="dark"] .replying {
+    background: #2a241f;
+  }
+
+  :root[data-color-scheme="dark"] .account-form input,
+  body[data-color-scheme="dark"] .account-form input,
+  :root[data-color-scheme="dark"] .compose-form textarea,
+  body[data-color-scheme="dark"] .compose-form textarea,
+  :root[data-color-scheme="dark"] .compose-actions select,
+  body[data-color-scheme="dark"] .compose-actions select,
+  :root[data-color-scheme="dark"] .settings-item select,
+  body[data-color-scheme="dark"] .settings-item select {
+    background: #151310;
+    border: 1px solid #3a312a;
+    color: #f0e7dc;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-form input,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-form input,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-form textarea,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-form textarea,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-actions select,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-actions select,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .settings-item select,
+  body[data-color-scheme="dark"][data-theme="christmas"] .settings-item select {
+    background: #1a100f;
+    border: 1px solid #3b2624;
+    color: #f7e7df;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-form input,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-form input,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-form textarea,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-form textarea,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-actions select,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-actions select,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .settings-item select,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .settings-item select {
+    background: #181e2a;
+    border: 1px solid #2e3b50;
+    color: #eff1f7;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-form input::placeholder,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-form input::placeholder,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-form textarea::placeholder,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-form textarea::placeholder {
+    color: #c59a9a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-form input::placeholder,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-form input::placeholder,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-form textarea::placeholder,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-form textarea::placeholder {
+    color: #aeb7c6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-form input,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-form input,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-form textarea,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-form textarea,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-actions select,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-actions select,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .settings-item select,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .settings-item select {
+    background: #101010;
+    border: 1px solid #3a3a3a;
+    color: #f0f0f0;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-form input::placeholder,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-form input::placeholder,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-form textarea::placeholder,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-form textarea::placeholder {
+    color: #8a8a8a;
+  }
+
+  :root[data-color-scheme="dark"] .account-form-divider,
+  body[data-color-scheme="dark"] .account-form-divider {
+    border-top: 1px dashed #3b342d;
+  }
+
+  :root[data-color-scheme="dark"] .account-form input::placeholder,
+  body[data-color-scheme="dark"] .account-form input::placeholder,
+  :root[data-color-scheme="dark"] .compose-form textarea::placeholder,
+  body[data-color-scheme="dark"] .compose-form textarea::placeholder {
+    color: #9b8e80;
+  }
+
+  :root[data-color-scheme="dark"] button,
+  body[data-color-scheme="dark"] button {
+    background: #4a6cb6;
+    color: #edf3ff;
+  }
+
+  :root[data-color-scheme="dark"] .settings-danger-button,
+  body[data-color-scheme="dark"] .settings-danger-button {
+    background: #b5463b;
+    color: #fff6f0;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] button,
+  body[data-color-scheme="dark"][data-theme="christmas"] button {
+    background: #8f2f2f;
+    color: #fff1f1;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .settings-danger-button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .settings-danger-button {
+    background: #a54343;
+    color: #fff1f1;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] button {
+    background: #7db4f0;
+    color: #0f1c2a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .settings-danger-button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .settings-danger-button {
+    background: #d97183;
+    color: #fff4f6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] button {
+    background: #e6e6e6;
+    color: #111111;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .settings-danger-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .settings-danger-button {
+    background: #d32f2f;
+    color: #fff5f5;
+  }
+
+  :root[data-color-scheme="dark"] button.is-active,
+  body[data-color-scheme="dark"] button.is-active {
+    background: #8fa6cf;
+    color: #1d2638;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] button.is-active,
+  body[data-color-scheme="dark"][data-theme="christmas"] button.is-active {
+    background: #b07a3b;
+    color: #2b1a10;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] button.is-active,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] button.is-active {
+    background: #f0a6c8;
+    color: #2a1620;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] button.is-active,
+  body[data-color-scheme="dark"][data-theme="monochrome"] button.is-active {
+    background: #bdbdbd;
+    color: #111111;
+  }
+
+  :root[data-color-scheme="dark"] button.ghost,
+  body[data-color-scheme="dark"] button.ghost {
+    color: #8fa6cf;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] button.ghost,
+  body[data-color-scheme="dark"][data-theme="christmas"] button.ghost {
+    color: #cf8c8c;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] button.ghost,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] button.ghost {
+    color: #f0a6c8;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] button.ghost,
+  body[data-color-scheme="dark"][data-theme="monochrome"] button.ghost {
+    color: #f0f0f0;
+  }
+
+  :root[data-color-scheme="dark"] .text-link,
+  body[data-color-scheme="dark"] .text-link {
+    color: #8fa6cf;
+    background: none;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .text-link,
+  body[data-color-scheme="dark"][data-theme="christmas"] .text-link {
+    color: #cf8c8c;
+    background: none;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .text-link,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .text-link {
+    color: #f0a6c8;
+    background: none;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .text-link,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .text-link {
+    color: #f0f0f0;
+    background: none;
+  }
+
+  :root[data-color-scheme="dark"] .account-add-button,
+  body[data-color-scheme="dark"] .account-add-button {
+    background: #4a6cb6;
+    color: #edf3ff;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-add-button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-add-button {
+    background: #2e6b4f;
+    color: #f4fff7;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-add-button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-add-button {
+    background: #7db4f0;
+    color: #0f1c2a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-add-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-add-button {
+    background: #e6e6e6;
+    color: #111111;
+  }
+
+  :root[data-color-scheme="dark"] .account-add-panel,
+  body[data-color-scheme="dark"] .account-add-panel {
+    background: rgba(23, 21, 18, 0.88);
+    color: #f0e7dc;
+    border: 1px solid #3b342d;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-add-panel,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-add-panel {
+    background: rgba(26, 16, 15, 0.88);
+    color: #f7e7df;
+    border: 1px solid #3b2624;
+    box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-add-panel,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-add-panel {
+    background: rgba(24, 30, 42, 0.9);
+    color: #eff1f7;
+    border: 1px solid #2e3b50;
+    box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-add-panel,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-add-panel {
+    background: rgba(16, 16, 16, 0.88);
+    color: #f0f0f0;
+    border: 1px solid #3a3a3a;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"] .section-menu-panel,
+  body[data-color-scheme="dark"] .section-menu-panel {
+    background: rgba(23, 21, 18, 0.88);
+    color: #f0e7dc;
+    border: 1px solid #3b342d;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"] .section-menu-panel button,
+  body[data-color-scheme="dark"] .section-menu-panel button {
+    color: #f0e7dc;
+  }
+
+  :root[data-color-scheme="dark"] .section-menu-panel .danger,
+  body[data-color-scheme="dark"] .section-menu-panel .danger {
+    color: #e07a6d;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .section-menu-panel .danger,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .section-menu-panel .danger {
+    color: #ff8a8a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .section-menu-panel,
+  body[data-color-scheme="dark"][data-theme="christmas"] .section-menu-panel {
+    background: rgba(26, 16, 15, 0.88);
+    color: #f7e7df;
+    border: 1px solid #3b2624;
+    box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .section-menu-panel button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .section-menu-panel button {
+    color: #f7e7df;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .section-menu-panel,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .section-menu-panel {
+    background: rgba(24, 30, 42, 0.9);
+    color: #eff1f7;
+    border: 1px solid #2e3b50;
+    box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .section-menu-panel button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .section-menu-panel button {
+    color: #eff1f7;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .section-menu-panel,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .section-menu-panel {
+    background: rgba(16, 16, 16, 0.88);
+    color: #f0f0f0;
+    border: 1px solid #3a3a3a;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .section-menu-panel button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .section-menu-panel button {
+    color: #f0f0f0;
+  }
+
+  :root[data-color-scheme="dark"] .account-selector-summary,
+  body[data-color-scheme="dark"] .account-selector-summary {
+    background: #171512;
+    border: 1px solid #3b342d;
+  }
+
+  :root[data-color-scheme="dark"] .account-selector-dropdown,
+  body[data-color-scheme="dark"] .account-selector-dropdown {
+    background: rgba(23, 21, 18, 0.88);
+    border: 1px solid #3b342d;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"] .account-selector-placeholder,
+  body[data-color-scheme="dark"] .account-selector-placeholder,
+  :root[data-color-scheme="dark"] .account-selector-caret,
+  body[data-color-scheme="dark"] .account-selector-caret {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-selector-summary,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-selector-summary {
+    background: #1a100f;
+    border: 1px solid #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-selector-dropdown,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-selector-dropdown {
+    background: rgba(26, 16, 15, 0.88);
+    border: 1px solid #3b2624;
+    box-shadow: 0 18px 40px rgba(64, 20, 20, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-summary,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-summary {
+    background: #181e2a;
+    border: 1px solid #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-dropdown,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-dropdown {
+    background: rgba(24, 30, 42, 0.9);
+    border: 1px solid #2e3b50;
+    box-shadow: 0 18px 40px rgba(12, 18, 28, 0.5);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-summary,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-summary {
+    background: #101010;
+    border: 1px solid #3a3a3a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-dropdown,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-dropdown {
+    background: rgba(16, 16, 16, 0.88);
+    border: 1px solid #3a3a3a;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-selector-placeholder,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-selector-placeholder,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-selector-caret,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-selector-caret {
+    color: #cf8c8c;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-placeholder,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-placeholder,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-caret,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .account-selector-caret {
+    color: #f0a6c8;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-summary .account-text,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-summary .account-text,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-dropdown .account-text,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-dropdown .account-text {
+    color: #f0f0f0;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-placeholder,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-placeholder,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-caret,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-selector-caret {
+    color: #cfcfcf;
+  }
+
+  :root[data-color-scheme="dark"] .sidebar-description,
+  body[data-color-scheme="dark"] .sidebar-description,
+  :root[data-color-scheme="dark"] .oss-list,
+  body[data-color-scheme="dark"] .oss-list {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"] .sidebar-description a,
+  body[data-color-scheme="dark"] .sidebar-description a {
+    color: #8fa6cf;
+  }
+
+  :root[data-color-scheme="dark"] .sidebar-links a,
+  body[data-color-scheme="dark"] .sidebar-links a {
+    color: #d7cbbd;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .sidebar-description,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .sidebar-description,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .oss-list,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .oss-list {
+    color: #d6d6d6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-description,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-description,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .oss-list,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .oss-list {
+    color: #d7ddea;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .sidebar-description a,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .sidebar-description a,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .sidebar-links a,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .sidebar-links a {
+    color: #f0f0f0;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .sidebar-links a,
+  body[data-color-scheme="dark"][data-theme="christmas"] .sidebar-links a {
+    color: #9cc7ab;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-description a,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-description a {
+    color: #9dbef4;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-links a,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-links a {
+    color: #f0a6c8;
+  }
+
+  :root[data-color-scheme="dark"] .sidebar-divider,
+  body[data-color-scheme="dark"] .sidebar-divider {
+    background: #3b342d;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .sidebar-divider,
+  body[data-color-scheme="dark"][data-theme="christmas"] .sidebar-divider {
+    background: #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-divider,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .sidebar-divider {
+    background: #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"] .settings-item,
+  body[data-color-scheme="dark"] .settings-item {
+    border-top: 1px solid #3b342d;
+  }
+
+  :root[data-color-scheme="dark"] .settings-item p,
+  body[data-color-scheme="dark"] .settings-item p {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .settings-item,
+  body[data-color-scheme="dark"][data-theme="christmas"] .settings-item {
+    border-top: 1px solid #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .settings-item,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .settings-item {
+    border-top: 1px solid #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .settings-item p,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .settings-item p {
+    color: #d7ddea;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .settings-item p,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .settings-item p {
+    color: #d6d6d6;
+  }
+
+  :root[data-color-scheme="dark"] .settings-modal-backdrop,
+  body[data-color-scheme="dark"] .settings-modal-backdrop {
+    background: rgba(8, 7, 6, 0.7);
+  }
+
+  :root[data-color-scheme="dark"] .back-link,
+  body[data-color-scheme="dark"] .back-link {
+    color: #d7cbbd;
+  }
+
+  :root[data-color-scheme="dark"] .boosted-by,
+  body[data-color-scheme="dark"] .boosted-by {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .boosted-by,
+  body[data-color-scheme="dark"][data-theme="christmas"] .boosted-by {
+    color: #9cc7ab;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .boosted-by,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .boosted-by {
+    color: #9dbef4;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .boosted-by,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .boosted-by {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"] .reply-info,
+  body[data-color-scheme="dark"] .reply-info {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .reply-info,
+  body[data-color-scheme="dark"][data-theme="christmas"] .reply-info {
+    color: #cf8c8c;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .reply-info,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .reply-info {
+    color: #f0a6c8;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .reply-info,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .reply-info {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"] .status-reaction,
+  body[data-color-scheme="dark"] .status-reaction {
+    color: #e9dfd2;
+    border-color: #5a4f45;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status-reaction,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status-reaction {
+    color: #f7e7df;
+    border-color: #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status-reaction,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status-reaction {
+    color: #eff1f7;
+    border-color: #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status-reaction,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status-reaction {
+    color: #d6d6d6;
+    border-color: #3a3a3a;
+  }
+
+  :root[data-color-scheme="dark"] .status-reaction.is-active,
+  body[data-color-scheme="dark"] .status-reaction.is-active {
+    background: #2c2722;
+    border-color: #6f5c47;
+    color: #fff7ec;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .status-reaction.is-active,
+  body[data-color-scheme="dark"][data-theme="christmas"] .status-reaction.is-active {
+    background: #2a1b19;
+    border-color: #3b2624;
+    color: #fff1f1;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .status-reaction.is-active,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .status-reaction.is-active {
+    background: #212a3a;
+    border-color: #2e3b50;
+    color: #f2f5fb;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .status-reaction.is-active,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .status-reaction.is-active {
+    background: #1a1a1a;
+    border-color: #4a4a4a;
+    color: #f5f5f5;
+  }
+
+  :root[data-color-scheme="dark"] .status-header,
+  body[data-color-scheme="dark"] .status-header {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"] .account-handle,
+  body[data-color-scheme="dark"] .account-handle {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .account-handle,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .account-handle {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"] .account-avatar,
+  body[data-color-scheme="dark"] .account-avatar {
+    background: #221f1b;
+    border: 1px solid #3b342d;
+  }
+
+  :root[data-color-scheme="dark"] .status-avatar,
+  body[data-color-scheme="dark"] .status-avatar {
+    background: #221f1b;
+    border: 1px solid #3b342d;
+  }
+
+  :root[data-color-scheme="dark"] .account-avatar-fallback,
+  body[data-color-scheme="dark"] .account-avatar-fallback {
+    background: #6c5c4b;
+  }
+
+  :root[data-color-scheme="dark"] .status-avatar-fallback,
+  body[data-color-scheme="dark"] .status-avatar-fallback {
+    background: #6c5c4b;
+  }
+
+  :root[data-color-scheme="dark"] .attachment-thumb,
+  body[data-color-scheme="dark"] .attachment-thumb {
+    border: 1px solid #3b342d;
+    background: #171512;
+  }
+
+  :root[data-color-scheme="dark"] .file-button,
+  body[data-color-scheme="dark"] .file-button {
+    background: #2c3b59;
+    color: #e1e7f4;
+  }
+
+  :root[data-color-scheme="dark"] .compose-icon-button,
+  body[data-color-scheme="dark"] .compose-icon-button {
+    background: #2c3b59;
+    color: #e1e7f4;
+    border-color: #3b342d;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .file-button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .file-button {
+    background: #2a1b19;
+    color: #f7e7df;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-icon-button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-icon-button {
+    background: #2a1b19;
+    color: #f7e7df;
+    border-color: #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .file-button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .file-button {
+    background: #223047;
+    color: #d7e7fb;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-icon-button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-icon-button {
+    background: #223047;
+    color: #d7e7fb;
+    border-color: #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .file-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .file-button,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-icon-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-icon-button {
+    background: #2a2a2a;
+    color: #f0f0f0;
+    border-color: #4a4a4a;
+  }
+
+  :root[data-color-scheme="dark"] .compose-emoji-panel,
+  body[data-color-scheme="dark"] .compose-emoji-panel {
+    background: #1b1916;
+    border-color: #3b342d;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-panel,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-panel {
+    background: #201412;
+    border-color: #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-panel,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-panel {
+    background: #181e2a;
+    border-color: #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-panel,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-panel {
+    background: #101010;
+    border-color: #3a3a3a;
+  }
+
+  :root[data-color-scheme="dark"] .compose-emoji-category-toggle,
+  body[data-color-scheme="dark"] .compose-emoji-category-toggle {
+    background: #2a2622;
+    color: #f0e7dc;
+    border-color: #3b342d;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-category-toggle,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-category-toggle {
+    background: #2a1b19;
+    color: #f7e7df;
+    border-color: #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-category-toggle,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-category-toggle {
+    background: #223047;
+    color: #eff1f7;
+    border-color: #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-category-toggle,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-category-toggle {
+    background: #1a1a1a;
+    color: #f5f5f5;
+    border-color: #3a3a3a;
+  }
+
+  :root[data-color-scheme="dark"] .compose-emoji-count,
+  body[data-color-scheme="dark"] .compose-emoji-count {
+    background: #2c3b59;
+    color: #e1e7f4;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-count,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-count {
+    background: #3b2624;
+    color: #f7e7df;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-count,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-count {
+    background: #344760;
+    color: #f2f5fb;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-count,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-count {
+    background: #2a2a2a;
+    color: #f0f0f0;
+  }
+
+  :root[data-color-scheme="dark"] .compose-emoji-button,
+  body[data-color-scheme="dark"] .compose-emoji-button {
+    background: #221f1b;
+    border-color: #3b342d;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-button {
+    background: #1a100f;
+    border-color: #3b2624;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-button,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-button {
+    background: #223047;
+    border-color: #2e3b50;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-button {
+    background: #1a1a1a;
+    border-color: #3a3a3a;
+  }
+
+  :root[data-color-scheme="dark"] .compose-emoji-empty,
+  body[data-color-scheme="dark"] .compose-emoji-empty {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-empty,
+  body[data-color-scheme="dark"][data-theme="christmas"] .compose-emoji-empty {
+    color: #cf8c8c;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-empty,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .compose-emoji-empty {
+    color: #b7c2d2;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-empty,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .compose-emoji-empty {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"] .link-preview,
+  body[data-color-scheme="dark"] .link-preview {
+    border: 1px solid #3b342d;
+    background: #171512;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .link-preview,
+  body[data-color-scheme="dark"][data-theme="christmas"] .link-preview {
+    border: 1px solid #3b2624;
+    background: #1a100f;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview {
+    border: 1px solid #2e3b50;
+    background: #181e2a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .link-preview,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .link-preview {
+    border: 1px solid #3a3a3a;
+    background: #101010;
+  }
+
+  :root[data-color-scheme="dark"] .link-preview-body,
+  body[data-color-scheme="dark"] .link-preview-body {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .link-preview-body,
+  body[data-color-scheme="dark"][data-theme="christmas"] .link-preview-body {
+    color: #e4b9b9;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview-body,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview-body {
+    color: #d7ddea;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .link-preview-body,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .link-preview-body {
+    color: #d6d6d6;
+  }
+
+  :root[data-color-scheme="dark"] .link-preview-body strong,
+  body[data-color-scheme="dark"] .link-preview-body strong {
+    color: #f0e7dc;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .link-preview-body strong,
+  body[data-color-scheme="dark"][data-theme="christmas"] .link-preview-body strong {
+    color: #f4d7d7;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview-body strong,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview-body strong {
+    color: #f2f5fb;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .link-preview-body strong,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .link-preview-body strong {
+    color: #f5f5f5;
+  }
+
+  :root[data-color-scheme="dark"] .link-preview-url,
+  body[data-color-scheme="dark"] .link-preview-url {
+    color: #d7cbbd;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .link-preview-url,
+  body[data-color-scheme="dark"][data-theme="christmas"] .link-preview-url {
+    color: #9cc7ab;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview-url,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .link-preview-url {
+    color: #9dbef4;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .link-preview-url,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .link-preview-url {
+    color: #bdbdbd;
+  }
+
+  :root[data-color-scheme="dark"] .readme-text,
+  body[data-color-scheme="dark"] .readme-text {
+    color: #c4b6a6;
+  }
+
+  :root[data-color-scheme="dark"] .readme-text a,
+  body[data-color-scheme="dark"] .readme-text a {
+    color: #d7cbbd;
+  }
+
+  :root[data-color-scheme="dark"] .readme-text code,
+  body[data-color-scheme="dark"] .readme-text code,
+  :root[data-color-scheme="dark"] .readme-text pre,
+  body[data-color-scheme="dark"] .readme-text pre {
+    background: #221f1b;
+  }
+
+  :root[data-color-scheme="dark"] .status-text a,
+  body[data-color-scheme="dark"] .status-text a {
+    color: #d7cbbd;
+  }
+
+  :root[data-color-scheme="dark"] .image-modal-backdrop,
+  body[data-color-scheme="dark"] .image-modal-backdrop {
+    background: rgba(8, 7, 6, 0.8);
+  }
+
+  :root[data-color-scheme="dark"] .image-modal-content img,
+  body[data-color-scheme="dark"] .image-modal-content img {
+    border: 1px solid #2f2923;
+    background: #0b0a09;
+  }
+
+  :root[data-color-scheme="dark"] .confirm-modal-content,
+  body[data-color-scheme="dark"] .confirm-modal-content {
+    background: #171512;
+    border: 1px solid #3b342d;
+  }
+
+  :root[data-color-scheme="dark"] .confirm-actions .delete-button,
+  body[data-color-scheme="dark"] .confirm-actions .delete-button {
+    color: #fffaf2;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .confirm-actions .delete-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .confirm-actions .delete-button {
+    color: #fff5f5;
+  }
+
+  :root[data-color-scheme="dark"] .confirm-status,
+  body[data-color-scheme="dark"] .confirm-status {
+    background: #171512;
+    border: 1px solid #302822;
+  }
+
+  :root[data-color-scheme="dark"] .image-modal-delete,
+  body[data-color-scheme="dark"] .image-modal-delete {
+    background: #7a3a2a;
+    color: #f5efe7;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .image-modal-delete,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .image-modal-delete {
+    background: #c62828;
+    color: #fff5f5;
+  }
+
+  :root[data-color-scheme="dark"] .delete-button,
+  body[data-color-scheme="dark"] .delete-button {
+    background: #7a3a2a;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .delete-button,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .delete-button {
+    background: #c62828;
+  }
+
+  :root[data-color-scheme="dark"] .license,
+  body[data-color-scheme="dark"] .license {
+    background: #221f1b;
+    border: 1px solid #3b342d;
+    color: #f0e7dc;
+  }
+


### PR DESCRIPTION
﻿## 요약
- 설정에 색상 모드(시스템/라이트/다크) 고정 옵션 추가
- 선택값을 로컬 저장소에 저장하고 data 속성으로 반영
- 다크 모드 스타일을 색상 모드 설정에 맞춰 적용

## 변경 사항
- App에서 색상 모드 상태/저장/DOM 반영 추가
- 설정 팝업에 색상 모드 선택 UI 추가
- base.css에 color-scheme 고정 처리 추가
- theme.css에서 색상 모드 고정 시 다크 스타일 적용/차단 규칙 추가

## 테스트
- 미실행 (로컬 확인 필요)
