### PR TITLE
테마 컬러 및 메뉴 텍스트 보정

### DIFF
--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -2531,6 +2531,17 @@ body[data-theme="monochrome"] .compose-icon-button {
     color: #cf8c8c;
   }
 
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-list button,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-list button {
+    background: none;
+    color: inherit;
+  }
+
+  :root[data-color-scheme="dark"][data-theme="christmas"] .account-list button.ghost,
+  body[data-color-scheme="dark"][data-theme="christmas"] .account-list button.ghost {
+    color: #cf8c8c;
+  }
+
   :root[data-color-scheme="dark"][data-theme="sky-pink"] button.ghost,
   body[data-color-scheme="dark"][data-theme="sky-pink"] button.ghost {
     color: #f0a6c8;


### PR DESCRIPTION
## 요약
- 테마별 텍스트 색상 보정(계정 핸들, 브랜드 부제, 본문 URL)
- 크리스마스 다크 모드 메뉴 버튼 배경 제거 및 텍스트 정리
- 계정 선택 메뉴 항목/삭제 버튼 배경 제거

## 변경 사항
- `src/ui/styles/theme.css` 내 테마/다크 모드 규칙 추가 및 조정

## 테스트
- 수동 확인(테마/다크 전환)
