### PR TITLE
알림 팝오버 및 타임라인 확장

### DIFF
--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -2,6 +2,8 @@ export type Visibility = "public" | "unlisted" | "private" | "direct";
 
 export type AccountPlatform = "mastodon" | "misskey";
 
+export type TimelineType = "home" | "local" | "federated" | "social" | "global" | "notifications";
+
 export type Account = {
   id: string;
   instanceUrl: string;
@@ -41,6 +43,20 @@ export type Reaction = {
   host: string | null;
 };
 
+export type NotificationActor = {
+  name: string;
+  handle: string;
+  url: string | null;
+  avatarUrl: string | null;
+};
+
+export type NotificationMeta = {
+  type: string;
+  label: string;
+  actor: NotificationActor;
+  target: Status | null;
+};
+
 export type LinkCard = {
   url: string;
   title: string;
@@ -72,6 +88,7 @@ export type Status = {
   mediaAttachments: MediaAttachment[];
   reblog: Status | null;
   boostedBy: { name: string; handle: string; url: string | null } | null;
+  notification: NotificationMeta | null;
   myReaction: string | null;
   customEmojis: CustomEmoji[];
   accountEmojis: CustomEmoji[];

--- a/src/infra/MisskeyStreamingClient.ts
+++ b/src/infra/MisskeyStreamingClient.ts
@@ -31,6 +31,9 @@ const mapMisskeyEvent = (
       if (channelBody.type === "note" && channelBody.body) {
         return { type: "update", status: mapMisskeyStatusWithInstance(channelBody.body, instanceUrl) };
       }
+      if (channelBody.type === "notification") {
+        return { type: "notification" };
+      }
       if (channelBody.type === "deleted") {
         const id =
           typeof channelBody.body === "string"
@@ -43,6 +46,9 @@ const mapMisskeyEvent = (
     }
     if (data.type === "note" && data.body) {
       return { type: "update", status: mapMisskeyStatusWithInstance(data.body, instanceUrl) };
+    }
+    if (data.type === "notification") {
+      return { type: "notification" };
     }
     return null;
   } catch {

--- a/src/infra/UnifiedApiClient.ts
+++ b/src/infra/UnifiedApiClient.ts
@@ -1,4 +1,4 @@
-import type { Account } from "../domain/types";
+import type { Account, TimelineType } from "../domain/types";
 import type { CustomEmoji } from "../domain/types";
 import type { CreateStatusInput, MastodonApi } from "../services/MastodonApi";
 
@@ -18,6 +18,10 @@ export class UnifiedApiClient implements MastodonApi {
 
   fetchHomeTimeline(account: Account, limit: number, maxId?: string) {
     return this.getClient(account).fetchHomeTimeline(account, limit, maxId);
+  }
+
+  fetchTimeline(account: Account, timeline: TimelineType, limit: number, maxId?: string) {
+    return this.getClient(account).fetchTimeline(account, timeline, limit, maxId);
   }
 
   fetchCustomEmojis(account: Account): Promise<CustomEmoji[]> {

--- a/src/services/MastodonApi.ts
+++ b/src/services/MastodonApi.ts
@@ -1,4 +1,4 @@
-import type { Account, Status, Visibility } from "../domain/types";
+import type { Account, Status, TimelineType, Visibility } from "../domain/types";
 import type { CustomEmoji } from "../domain/types";
 
 export type CreateStatusInput = {
@@ -11,6 +11,7 @@ export type CreateStatusInput = {
 export interface MastodonApi {
   verifyAccount(account: Account): Promise<{ accountName: string; handle: string; avatarUrl: string | null }>;
   fetchHomeTimeline(account: Account, limit: number, maxId?: string): Promise<Status[]>;
+  fetchTimeline(account: Account, timeline: TimelineType, limit: number, maxId?: string): Promise<Status[]>;
   fetchCustomEmojis(account: Account): Promise<CustomEmoji[]>;
   uploadMedia(account: Account, file: File): Promise<string>;
   createStatus(account: Account, input: CreateStatusInput): Promise<Status>;

--- a/src/ui/components/AccountSelector.tsx
+++ b/src/ui/components/AccountSelector.tsx
@@ -1,17 +1,22 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import type { Account } from "../../domain/types";
+import type { Account, TimelineType } from "../../domain/types";
 import { formatHandle } from "../utils/account";
+import { getTimelineOptions } from "../utils/timeline";
 
 export const AccountSelector = ({
   accounts,
   activeAccountId,
   setActiveAccount,
+  activeTimeline,
+  setActiveTimeline,
   removeAccount,
   variant = "panel"
 }: {
   accounts: Account[];
   activeAccountId: string | null;
   setActiveAccount: (id: string) => void;
+  activeTimeline?: TimelineType;
+  setActiveTimeline?: (timeline: TimelineType) => void;
   removeAccount: (id: string) => void;
   variant?: "panel" | "inline";
 }) => {
@@ -40,6 +45,7 @@ export const AccountSelector = ({
     () => accounts.find((account) => account.id === activeAccountId) ?? null,
     [accounts, activeAccountId]
   );
+  const showTimelineSelector = Boolean(setActiveTimeline);
 
   const wrapperClassName =
     variant === "panel" ? "panel account-selector-panel" : "account-selector-inline";
@@ -89,38 +95,66 @@ export const AccountSelector = ({
           ) : null}
           <div className="account-selector-dropdown">
             <ul className="account-list">
-              {accounts.map((account) => (
-                <li key={account.id} className={account.id === activeAccountId ? "active" : ""}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setActiveAccount(account.id);
-                      setDropdownOpen(false);
-                    }}
-                  >
-                    <span className="account-label">
-                      <span className="account-avatar" aria-hidden="true">
-                        {account.avatarUrl ? (
-                          <img src={account.avatarUrl} alt="" loading="lazy" />
-                        ) : (
-                          <span className="account-avatar-fallback" />
-                        )}
-                      </span>
-                      <span className="account-text">
-                        <span>{account.displayName || account.name || account.instanceUrl}</span>
-                        {account.handle ? (
-                          <span className="account-handle">
-                            @{formatHandle(account.handle, account.instanceUrl)}
+              {accounts.map((account) => {
+                const isActiveAccount = account.id === activeAccountId;
+                const timelineOptions = getTimelineOptions(account.platform, false);
+                return (
+                  <li key={account.id} className={isActiveAccount ? "active" : ""}>
+                    <div className="account-row">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActiveAccount(account.id);
+                          setDropdownOpen(false);
+                        }}
+                      >
+                        <span className="account-label">
+                          <span className="account-avatar" aria-hidden="true">
+                            {account.avatarUrl ? (
+                              <img src={account.avatarUrl} alt="" loading="lazy" />
+                            ) : (
+                              <span className="account-avatar-fallback" />
+                            )}
                           </span>
-                        ) : null}
-                      </span>
-                    </span>
-                  </button>
-                  <button type="button" onClick={() => removeAccount(account.id)} className="ghost">
-                    삭제
-                  </button>
-                </li>
-              ))}
+                          <span className="account-text">
+                            <span>{account.displayName || account.name || account.instanceUrl}</span>
+                            {account.handle ? (
+                              <span className="account-handle">
+                                @{formatHandle(account.handle, account.instanceUrl)}
+                              </span>
+                            ) : null}
+                          </span>
+                        </span>
+                      </button>
+                      <button type="button" onClick={() => removeAccount(account.id)} className="ghost">
+                        삭제
+                      </button>
+                    </div>
+                    {showTimelineSelector ? (
+                      <div className="account-timeline-options" role="group" aria-label="타임라인 선택">
+                        {timelineOptions.map((option) => {
+                          const isSelected = isActiveAccount && activeTimeline === option.id;
+                          return (
+                            <button
+                              key={option.id}
+                              type="button"
+                              className={`account-timeline-option${isSelected ? " is-active" : ""}`}
+                              aria-pressed={isSelected}
+                              onClick={() => {
+                                setActiveAccount(account.id);
+                                setActiveTimeline?.(option.id);
+                                setDropdownOpen(false);
+                              }}
+                            >
+                              {option.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
               {accounts.length === 0 ? <li className="empty">등록된 계정이 없습니다.</li> : null}
             </ul>
           </div>

--- a/src/ui/styles/base.css
+++ b/src/ui/styles/base.css
@@ -7,6 +7,9 @@
   --scrollbar-thumb-dark: #3b342d;
   --timeline-column-width: 440px;
   --timeline-column-max-width: 520px;
+  --notification-badge-bg: #c04b3c;
+  --notification-badge-text: #fff6f0;
+  --notification-badge-ring: #fffdfa;
 }
 
 :root[data-color-scheme="light"] {

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -247,17 +247,24 @@
 
 .account-list li {
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.account-row {
+  display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 8px;
 }
 
-.account-list li > button:first-child {
+.account-row > button:first-child {
   flex: 1 1 auto;
   min-width: 0;
 }
 
-.account-list li.active button:first-child {
+.account-list li.active .account-row > button:first-child {
   font-weight: 700;
 }
 
@@ -268,6 +275,30 @@
   cursor: pointer;
   padding: 0;
   text-align: left;
+}
+
+.account-timeline-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-left: 42px;
+}
+
+.account-selector-dropdown .account-list .account-timeline-option {
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.account-selector-dropdown .account-list .account-timeline-option.is-active {
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .account-label {
@@ -697,6 +728,13 @@ button.ghost {
   gap: 8px;
 }
 
+.overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 13, 11, 0.12);
+  z-index: 15;
+}
+
 .section-menu {
   position: relative;
 }
@@ -744,6 +782,59 @@ button.ghost {
 .section-menu-panel .danger {
   color: #9a2e1f;
   font-weight: 600;
+}
+
+.notification-menu {
+  position: relative;
+}
+
+.notification-menu .icon-button {
+  position: relative;
+}
+
+.notification-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--notification-badge-bg);
+  color: var(--notification-badge-text);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 18px;
+  text-align: center;
+  box-shadow: 0 0 0 2px var(--notification-badge-ring);
+}
+
+.notification-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(380px, 92vw);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 30;
+}
+
+.notification-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.notification-popover-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 6px;
 }
 
 .timeline-column-body {
@@ -1209,6 +1300,22 @@ button.ghost {
 .boosted-by img {
   width: 18px;
   height: 18px;
+}
+
+.notification-actor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #7c6152;
+  margin-bottom: 8px;
+}
+
+.notification-actor-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .reply-info {

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -230,7 +230,8 @@ body[data-theme="christmas"] .compose-icon-button {
   color: #a36a6a;
 }
 
-:root[data-theme="christmas"] .boosted-by {
+:root[data-theme="christmas"] .boosted-by,
+:root[data-theme="christmas"] .notification-actor {
   color: #2e6b4f;
 }
 
@@ -484,7 +485,8 @@ body[data-theme="sky-pink"] .compose-icon-button {
   color: #9b7a8b;
 }
 
-:root[data-theme="sky-pink"] .boosted-by {
+:root[data-theme="sky-pink"] .boosted-by,
+:root[data-theme="sky-pink"] .notification-actor {
   color: #4a8bd8;
 }
 
@@ -751,7 +753,8 @@ body[data-theme="monochrome"] .compose-icon-button {
   color: #6b6b6b;
 }
 
-:root[data-theme="monochrome"] .boosted-by {
+:root[data-theme="monochrome"] .boosted-by,
+:root[data-theme="monochrome"] .notification-actor {
   color: #2a2a2a;
 }
 
@@ -778,12 +781,14 @@ body[data-theme="monochrome"] .compose-icon-button {
     background: radial-gradient(circle at top left, #1d1b18, #12110f 55%, #0d0c0b);
     color: #f0e7dc;
     --scrollbar-thumb: var(--scrollbar-thumb-dark);
+    --notification-badge-ring: #1b1916;
   }
 
   :root:not([data-color-scheme="light"])[data-theme="christmas"],
   body:not([data-color-scheme="light"])[data-theme="christmas"] {
     background: radial-gradient(circle at top left, #2a1716, #1d1110 55%, #120b0a);
     color: #f7e7df;
+    --notification-badge-ring: #201412;
   }
 
   :root:not([data-color-scheme="light"])[data-theme="sky-pink"],
@@ -791,6 +796,7 @@ body[data-theme="monochrome"] .compose-icon-button {
     background: radial-gradient(circle at top left, #1b2330, #191a26 55%, #101218);
     color: #eff1f7;
     --scrollbar-thumb: #5f6875;
+    --notification-badge-ring: #1a202d;
   }
 
   :root:not([data-color-scheme="light"])[data-theme="monochrome"],
@@ -798,6 +804,7 @@ body[data-theme="monochrome"] .compose-icon-button {
     background: radial-gradient(circle at top left, #0f0f0f, #080808 55%, #030303);
     color: #f5f5f5;
     --scrollbar-thumb: #616161;
+    --notification-badge-ring: #121212;
   }
 
   :root:not([data-color-scheme="light"]) .overlay-backdrop,
@@ -1612,22 +1619,30 @@ body[data-theme="monochrome"] .compose-icon-button {
   }
 
   :root:not([data-color-scheme="light"]) .boosted-by,
-  body:not([data-color-scheme="light"]) .boosted-by {
+  body:not([data-color-scheme="light"]) .boosted-by,
+  :root:not([data-color-scheme="light"]) .notification-actor,
+  body:not([data-color-scheme="light"]) .notification-actor {
     color: #c4b6a6;
   }
 
   :root:not([data-color-scheme="light"])[data-theme="christmas"] .boosted-by,
-  body:not([data-color-scheme="light"])[data-theme="christmas"] .boosted-by {
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .boosted-by,
+  :root:not([data-color-scheme="light"])[data-theme="christmas"] .notification-actor,
+  body:not([data-color-scheme="light"])[data-theme="christmas"] .notification-actor {
     color: #9cc7ab;
   }
 
   :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .boosted-by,
-  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .boosted-by {
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .boosted-by,
+  :root:not([data-color-scheme="light"])[data-theme="sky-pink"] .notification-actor,
+  body:not([data-color-scheme="light"])[data-theme="sky-pink"] .notification-actor {
     color: #9dbef4;
   }
 
   :root:not([data-color-scheme="light"])[data-theme="monochrome"] .boosted-by,
-  body:not([data-color-scheme="light"])[data-theme="monochrome"] .boosted-by {
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .boosted-by,
+  :root:not([data-color-scheme="light"])[data-theme="monochrome"] .notification-actor,
+  body:not([data-color-scheme="light"])[data-theme="monochrome"] .notification-actor {
     color: #bdbdbd;
   }
 
@@ -2098,31 +2113,35 @@ body[data-theme="monochrome"] .compose-icon-button {
   }
 }
 
-  :root[data-color-scheme="dark"] {
-    background: radial-gradient(circle at top left, #1d1b18, #12110f 55%, #0d0c0b);
-    color: #f0e7dc;
-    --scrollbar-thumb: var(--scrollbar-thumb-dark);
-  }
+:root[data-color-scheme="dark"] {
+  background: radial-gradient(circle at top left, #1d1b18, #12110f 55%, #0d0c0b);
+  color: #f0e7dc;
+  --scrollbar-thumb: var(--scrollbar-thumb-dark);
+  --notification-badge-ring: #1b1916;
+}
 
-  :root[data-color-scheme="dark"][data-theme="christmas"],
-  body[data-color-scheme="dark"][data-theme="christmas"] {
-    background: radial-gradient(circle at top left, #2a1716, #1d1110 55%, #120b0a);
-    color: #f7e7df;
-  }
+:root[data-color-scheme="dark"][data-theme="christmas"],
+body[data-color-scheme="dark"][data-theme="christmas"] {
+  background: radial-gradient(circle at top left, #2a1716, #1d1110 55%, #120b0a);
+  color: #f7e7df;
+  --notification-badge-ring: #201412;
+}
 
-  :root[data-color-scheme="dark"][data-theme="sky-pink"],
-  body[data-color-scheme="dark"][data-theme="sky-pink"] {
-    background: radial-gradient(circle at top left, #1b2330, #191a26 55%, #101218);
-    color: #eff1f7;
-    --scrollbar-thumb: #5f6875;
-  }
+:root[data-color-scheme="dark"][data-theme="sky-pink"],
+body[data-color-scheme="dark"][data-theme="sky-pink"] {
+  background: radial-gradient(circle at top left, #1b2330, #191a26 55%, #101218);
+  color: #eff1f7;
+  --scrollbar-thumb: #5f6875;
+  --notification-badge-ring: #1a202d;
+}
 
-  :root[data-color-scheme="dark"][data-theme="monochrome"],
-  body[data-color-scheme="dark"][data-theme="monochrome"] {
-    background: radial-gradient(circle at top left, #0f0f0f, #080808 55%, #030303);
-    color: #f5f5f5;
-    --scrollbar-thumb: #616161;
-  }
+:root[data-color-scheme="dark"][data-theme="monochrome"],
+body[data-color-scheme="dark"][data-theme="monochrome"] {
+  background: radial-gradient(circle at top left, #0f0f0f, #080808 55%, #030303);
+  color: #f5f5f5;
+  --scrollbar-thumb: #616161;
+  --notification-badge-ring: #121212;
+}
 
   :root[data-color-scheme="dark"] .overlay-backdrop,
   body[data-color-scheme="dark"] .overlay-backdrop {
@@ -2948,22 +2967,30 @@ body[data-theme="monochrome"] .compose-icon-button {
   }
 
   :root[data-color-scheme="dark"] .boosted-by,
-  body[data-color-scheme="dark"] .boosted-by {
+  body[data-color-scheme="dark"] .boosted-by,
+  :root[data-color-scheme="dark"] .notification-actor,
+  body[data-color-scheme="dark"] .notification-actor {
     color: #c4b6a6;
   }
 
   :root[data-color-scheme="dark"][data-theme="christmas"] .boosted-by,
-  body[data-color-scheme="dark"][data-theme="christmas"] .boosted-by {
+  body[data-color-scheme="dark"][data-theme="christmas"] .boosted-by,
+  :root[data-color-scheme="dark"][data-theme="christmas"] .notification-actor,
+  body[data-color-scheme="dark"][data-theme="christmas"] .notification-actor {
     color: #9cc7ab;
   }
 
   :root[data-color-scheme="dark"][data-theme="sky-pink"] .boosted-by,
-  body[data-color-scheme="dark"][data-theme="sky-pink"] .boosted-by {
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .boosted-by,
+  :root[data-color-scheme="dark"][data-theme="sky-pink"] .notification-actor,
+  body[data-color-scheme="dark"][data-theme="sky-pink"] .notification-actor {
     color: #9dbef4;
   }
 
   :root[data-color-scheme="dark"][data-theme="monochrome"] .boosted-by,
-  body[data-color-scheme="dark"][data-theme="monochrome"] .boosted-by {
+  body[data-color-scheme="dark"][data-theme="monochrome"] .boosted-by,
+  :root[data-color-scheme="dark"][data-theme="monochrome"] .notification-actor,
+  body[data-color-scheme="dark"][data-theme="monochrome"] .notification-actor {
     color: #bdbdbd;
   }
 

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -1,0 +1,64 @@
+import type { AccountPlatform, TimelineType } from "../../domain/types";
+
+export type TimelineOption = {
+  id: TimelineType;
+  label: string;
+};
+
+const TIMELINE_LABELS: Record<TimelineType, string> = {
+  home: "홈",
+  local: "로컬",
+  federated: "연합",
+  social: "소셜",
+  global: "글로벌",
+  notifications: "알림"
+};
+
+const MASTODON_TIMELINES: TimelineType[] = ["home", "local", "federated", "notifications"];
+const MISSKEY_TIMELINES: TimelineType[] = ["home", "local", "social", "global", "notifications"];
+const ALL_TIMELINES: TimelineType[] = [
+  "home",
+  "local",
+  "federated",
+  "social",
+  "global",
+  "notifications"
+];
+const TIMELINE_TYPE_SET = new Set<string>(ALL_TIMELINES);
+
+export const isTimelineType = (value: string): value is TimelineType => {
+  return TIMELINE_TYPE_SET.has(value);
+};
+
+export const getTimelineOptions = (
+  platform?: AccountPlatform | null,
+  includeNotifications = true
+): TimelineOption[] => {
+  const baseList =
+    platform === "mastodon"
+      ? MASTODON_TIMELINES
+      : platform === "misskey"
+        ? MISSKEY_TIMELINES
+        : ALL_TIMELINES;
+  const list = includeNotifications ? baseList : baseList.filter((id) => id !== "notifications");
+  return list.map((id) => ({
+    id,
+    label: TIMELINE_LABELS[id]
+  }));
+};
+
+export const normalizeTimelineType = (
+  value: string | TimelineType | null | undefined,
+  platform?: AccountPlatform | null,
+  includeNotifications = true
+): TimelineType => {
+  if (!value || !isTimelineType(value)) {
+    return "home";
+  }
+  const allowed =
+    platform === "mastodon" ? MASTODON_TIMELINES : platform === "misskey" ? MISSKEY_TIMELINES : ALL_TIMELINES;
+  const filtered = includeNotifications ? allowed : allowed.filter((timeline) => timeline !== "notifications");
+  return filtered.includes(value) ? value : "home";
+};
+
+export const getTimelineLabel = (timeline: TimelineType): string => TIMELINE_LABELS[timeline];


### PR DESCRIPTION
## 요약
- 알림 팝오버 및 스트리밍 배지 추가
- 마스토돈/미스키 타임라인 옵션 확장
- 알림 데이터 매핑/표시 개선

## 변경 사항
- 계정별 타임라인 선택 UI 재구성
- 알림 타임라인 팝오버 + 외부 클릭 닫기
- 알림 매핑 및 스트리밍 이벤트 처리 보강

## 테스트
- 테스트 미실행