### PR TITLE
섹션 최상단 이동 플로팅 버튼 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -399,11 +399,6 @@ const TimelineSection = ({
                   >
                     새로고침
                   </button>
-                  <div className="section-menu-mobile">
-                    <button type="button" onClick={scrollToTop}>
-                      최상단으로
-                    </button>
-                  </div>
                   <button
                     type="button"
                     onClick={() => {
@@ -539,19 +534,6 @@ const TimelineSection = ({
               </>
             ) : null}
           </div>
-          <button
-            type="button"
-            className="icon-button"
-            onClick={scrollToTop}
-            disabled={isAtTop}
-            aria-label="Scroll to top"
-            title="Scroll to top"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M12 19V5" />
-              <path d="M5 12l7-7 7 7" />
-            </svg>
-          </button>
         </div>
       </div>
       <div className="timeline-column-body" ref={scrollRef}>
@@ -585,6 +567,19 @@ const TimelineSection = ({
         ) : null}
         {timeline.loadingMore ? <p className="empty">더 불러오는 중...</p> : null}
       </div>
+      <button
+        type="button"
+        className="icon-button scroll-top-fab"
+        onClick={scrollToTop}
+        disabled={isAtTop}
+        aria-label="최상단으로 이동"
+        title="최상단으로 이동"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 19V5" />
+          <path d="M5 12l7-7 7 7" />
+        </svg>
+      </button>
     </div>
   );
 };

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -708,6 +708,7 @@ button.ghost {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  position: relative;
   background: #fffdfa;
   border: 1px solid #e2ddd5;
   border-radius: 14px;
@@ -753,21 +754,6 @@ button.ghost {
   flex-direction: column;
   gap: 4px;
   z-index: 20;
-}
-
-.section-menu-mobile {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #e2ddd5;
-  margin-bottom: 4px;
-}
-
-@media (max-width: 900px) {
-  .section-menu-mobile {
-    display: flex;
-  }
 }
 
 .section-menu-panel button {
@@ -841,6 +827,14 @@ button.ghost {
   overflow-y: auto;
   max-height: 85vh;
   padding-right: 6px;
+}
+
+.scroll-top-fab {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  z-index: 5;
+  box-shadow: 0 12px 24px rgba(67, 57, 45, 0.16);
 }
 
 .timeline {


### PR DESCRIPTION
## 요약
- 섹션 헤더의 최상단 이동 버튼 제거
- 섹션 내부 우하단 플로팅 버튼 추가
- 모바일 섹션 메뉴의 최상단 이동 항목 제거

## 테스트
- 미실행
