### PR TITLE
타임라인 선택 버튼 분리 및 정렬

### DIFF
--- a/src/ui/components/AccountSelector.tsx
+++ b/src/ui/components/AccountSelector.tsx
@@ -1,22 +1,17 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import type { Account, TimelineType } from "../../domain/types";
+import type { Account } from "../../domain/types";
 import { formatHandle } from "../utils/account";
-import { getTimelineOptions } from "../utils/timeline";
 
 export const AccountSelector = ({
   accounts,
   activeAccountId,
   setActiveAccount,
-  activeTimeline,
-  setActiveTimeline,
   removeAccount,
   variant = "panel"
 }: {
   accounts: Account[];
   activeAccountId: string | null;
   setActiveAccount: (id: string) => void;
-  activeTimeline?: TimelineType;
-  setActiveTimeline?: (timeline: TimelineType) => void;
   removeAccount: (id: string) => void;
   variant?: "panel" | "inline";
 }) => {
@@ -45,7 +40,6 @@ export const AccountSelector = ({
     () => accounts.find((account) => account.id === activeAccountId) ?? null,
     [accounts, activeAccountId]
   );
-  const showTimelineSelector = Boolean(setActiveTimeline);
 
   const wrapperClassName =
     variant === "panel" ? "panel account-selector-panel" : "account-selector-inline";
@@ -97,7 +91,6 @@ export const AccountSelector = ({
             <ul className="account-list">
               {accounts.map((account) => {
                 const isActiveAccount = account.id === activeAccountId;
-                const timelineOptions = getTimelineOptions(account.platform, false);
                 return (
                   <li key={account.id} className={isActiveAccount ? "active" : ""}>
                     <div className="account-row">
@@ -130,28 +123,6 @@ export const AccountSelector = ({
                         삭제
                       </button>
                     </div>
-                    {showTimelineSelector ? (
-                      <div className="account-timeline-options" role="group" aria-label="타임라인 선택">
-                        {timelineOptions.map((option) => {
-                          const isSelected = isActiveAccount && activeTimeline === option.id;
-                          return (
-                            <button
-                              key={option.id}
-                              type="button"
-                              className={`account-timeline-option${isSelected ? " is-active" : ""}`}
-                              aria-pressed={isSelected}
-                              onClick={() => {
-                                setActiveAccount(account.id);
-                                setActiveTimeline?.(option.id);
-                                setDropdownOpen(false);
-                              }}
-                            >
-                              {option.label}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    ) : null}
                   </li>
                 );
               })}

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -277,30 +277,6 @@
   text-align: left;
 }
 
-.account-timeline-options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding-left: 42px;
-}
-
-.account-selector-dropdown .account-list .account-timeline-option {
-  border: 1px solid currentColor;
-  background: transparent;
-  color: inherit;
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-size: 12px;
-  line-height: 1.1;
-  text-align: center;
-}
-
-.account-selector-dropdown .account-list .account-timeline-option.is-active {
-  font-weight: 700;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
 .account-label {
   display: flex;
   align-items: center;
@@ -727,6 +703,55 @@ button.ghost {
 .timeline-column-actions {
   display: flex;
   gap: 8px;
+}
+
+.timeline-selector {
+  position: relative;
+}
+
+.timeline-selector-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 40px;
+  padding: 0 12px;
+}
+
+.timeline-selector-button svg,
+.timeline-selector-button svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.timeline-selector-label {
+  font-size: 13px;
+}
+
+.timeline-selector-panel {
+  left: 0;
+  right: auto;
+  min-width: 180px;
+}
+
+.timeline-selector-panel button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.timeline-selector-panel svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .overlay-backdrop {

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -316,11 +316,7 @@ body[data-theme="sky-pink"] .overlay-backdrop {
   background: #c7d9ef;
 }
 
-:root[data-theme="sky-pink"] .account-selector-summary {
-  border: 1px solid #d6e5f2;
-  background: #f7fbff;
-}
-
+:root[data-theme="sky-pink"] .account-selector-summary,
 :root[data-theme="sky-pink"] .account-selector-dropdown {
   border: 1px solid #d6e5f2;
   background: #f7fbff;
@@ -571,11 +567,7 @@ body[data-theme="monochrome"] .overlay-backdrop {
   background: #b3b3b3;
 }
 
-:root[data-theme="monochrome"] .account-selector-summary {
-  border: 1px solid #1d1d1d;
-  background: #ffffff;
-}
-
+:root[data-theme="monochrome"] .account-selector-summary,
 :root[data-theme="monochrome"] .account-selector-dropdown {
   border: 1px solid #1d1d1d;
   background: rgba(255, 255, 255, 0.92);


### PR DESCRIPTION
## 변경 사항
- 계정 선택 드롭다운에서 타임라인 선택을 분리하고 섹션 헤더에 버튼으로 배치
- 타임라인 버튼 팝오버 및 아이콘/라벨 표시 구성
- 알림/햄버거 버튼과 유사한 버튼 스타일로 정리

## 테스트
- 미실행 (필요 시 안내)