### PR TITLE
타임라인별 스트리밍 연결 지원

### DIFF
--- a/src/infra/UnifiedStreamingClient.ts
+++ b/src/infra/UnifiedStreamingClient.ts
@@ -1,4 +1,4 @@
-import type { Account } from "../domain/types";
+import type { Account, TimelineType } from "../domain/types";
 import type { StreamingClient } from "../services/StreamingClient";
 
 export class UnifiedStreamingClient implements StreamingClient {
@@ -7,10 +7,14 @@ export class UnifiedStreamingClient implements StreamingClient {
     private readonly misskey: StreamingClient
   ) {}
 
-  connect(account: Account, onEvent: Parameters<StreamingClient["connect"]>[1]): () => void {
+  connect(
+    account: Account,
+    timelineType: TimelineType,
+    onEvent: Parameters<StreamingClient["connect"]>[2]
+  ): () => void {
     if (account.platform === "misskey") {
-      return this.misskey.connect(account, onEvent);
+      return this.misskey.connect(account, timelineType, onEvent);
     }
-    return this.mastodon.connect(account, onEvent);
+    return this.mastodon.connect(account, timelineType, onEvent);
   }
 }

--- a/src/services/StreamingClient.ts
+++ b/src/services/StreamingClient.ts
@@ -1,4 +1,4 @@
-import type { Account, Status } from "../domain/types";
+import type { Account, Status, TimelineType } from "../domain/types";
 
 export type StreamingEvent =
   | { type: "update"; status: Status }
@@ -6,5 +6,5 @@ export type StreamingEvent =
   | { type: "notification" };
 
 export interface StreamingClient {
-  connect(account: Account, onEvent: (event: StreamingEvent) => void): () => void;
+  connect(account: Account, timelineType: TimelineType, onEvent: (event: StreamingEvent) => void): () => void;
 }


### PR DESCRIPTION
## 변경 사항
- 스트리밍 클라이언트를 타임라인 타입을 받도록 확장
- 마스토돈/미스키 타임라인별 스트림 채널 매핑
- 타임라인 훅에서 알림 배지 스트림을 보완

## 테스트
- 테스트 미실행