### PR TITLE
외부 링크 새 탭에서 열리도록 수정

### DIFF
--- a/src/ui/utils/htmlSanitizer.ts
+++ b/src/ui/utils/htmlSanitizer.ts
@@ -5,12 +5,32 @@ import DOMPurify from 'dompurify';
  * Allows basic formatting tags for rich content display
  */
 export const sanitizeHtml = (html: string): string => {
-  return DOMPurify.sanitize(html, {
+  // Pre-process HTML to add target="_blank" to all external links
+  const processedHtml = html.replace(/<a\s+([^>]*)href="([^"]*)"([^>]*)>/gi, (match, attrs, href, rest) => {
+    // Check if it's an external link (starts with http)
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+      // Add target="_blank" and rel="noreferrer" if not already present
+      const hasTarget = /target\s*=\s*["'][^"']*["']/.test(attrs + rest);
+      const hasRel = /rel\s*=\s*["'][^"']*["']/.test(attrs + rest);
+      
+      let newAttrs = attrs + rest;
+      if (!hasTarget) {
+        newAttrs += ' target="_blank"';
+      }
+      if (!hasRel) {
+        newAttrs += ' rel="noreferrer"';
+      }
+      return `<a ${newAttrs}href="${href}">`;
+    }
+    return match;
+  });
+
+  return DOMPurify.sanitize(processedHtml, {
     ALLOWED_TAGS: [
       'p', 'br', 'a', 'strong', 'em', 'u', 's', 'code', 'pre',
       'blockquote', 'ul', 'ol', 'li', 'span', 'img'
     ],
-    ALLOWED_ATTR: ['href', 'title', 'class', 'src', 'alt', 'loading'],
+    ALLOWED_ATTR: ['href', 'title', 'class', 'src', 'alt', 'loading', 'target', 'rel'],
     FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
     ALLOW_DATA_ATTR: false,
   });


### PR DESCRIPTION
## Summary
- HTML sanitizer에서 외부 링크에 자동으로 target="_blank"와 rel="noreferrer" 추가
- ALLOWED_ATTR에 target, rel 속성 포함하여 보존되도록 수정
- 모든 외부 링크가 새 탭에서 열리도록 통일

## Details
게시물 내 HTML 콘텐츠에 포함된 외부 링크가 현재 탭에서 열리는 문제를 수정했습니다. DOMPurify sanitizer 설정으로 인해 target="_blank" 속성이 제거되는 현상을 해결하고, 모든 외부 링크가 일관되게 새 탭에서 열리도록 개선했습니다.