### PR TITLE
(alpha) 액션 표시에서 전체 핸들(@username@domain) 제거

### DIFF
--- a/src/ui/components/TimelineItem.tsx
+++ b/src/ui/components/TimelineItem.tsx
@@ -95,10 +95,10 @@ export const TimelineItem = ({
     }
     if (boostedBy) {
       const label = boostedBy.name || boostedHandle || boostedBy.handle;
-      return `${label} 님이 부스트함(@${boostedHandle ?? boostedBy.handle})`;
+      return `${label} 님이 부스트함`;
     }
     if (displayStatus.reblogged) {
-      return activeHandle ? `내가 부스트함(@${activeHandle})` : "내가 부스트함";
+      return "내가 부스트함";
     }
     return null;
   }, [boostedBy, boostedHandle, displayStatus.reblogged, activeHandle, notification]);
@@ -129,8 +129,7 @@ export const TimelineItem = ({
     }
     const actorName =
       notification.actor.name || notificationActorHandle || notification.actor.handle || "알 수 없음";
-    const handleSuffix = notificationActorHandle ? `(@${notificationActorHandle})` : "";
-    return `${actorName} 님이 ${notification.label}${handleSuffix}`;
+    return `${actorName} 님이 ${notification.label}`;
   }, [notification, notificationActorHandle]);
   const timestamp = useMemo(
     () => new Date(displayStatus.createdAt).toLocaleString(),


### PR DESCRIPTION
- 부스트 표시에서 핸들 정보 제거: "OOO 님이 부스트함(@handle)" → "OOO 님이 부스트함"
- 자체 부스트 표시 간소화: "내가 부스트함(@handle)" → "내가 부스트함"
- 알림 액터 표시에서 핸 정보 제거: "OOO 님이 액션(@handle)" → "OOO 님이 액션"
- UI를 더 깔끔하게 만들고 불필요한 정보 중복 제거

Fixes #82
Duplicated #86 