### PR TITLE
fix: 스레드 API 호출 시 올바른 계정 정보 사용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,8 +173,9 @@ const TimelineSection = ({
   onAddSectionRight: (sectionId: string) => void;
   onRemoveSection: (sectionId: string) => void;
   onReply: (status: Status, account: Account | null) => void;
-  onStatusClick: (status: Status) => void;
+  onStatusClick: (status: Status, columnAccount: Account | null) => void;
   onError: (message: string | null) => void;
+  columnAccount: Account | null;
   onMoveSection: (sectionId: string, direction: "left" | "right") => void;
   onCloseStatusModal: () => void;
   canMoveLeft: boolean;
@@ -569,9 +570,9 @@ const TimelineSection = ({
                           <TimelineItem
                             key={status.id}
                             status={status}
-                            onReply={(item) => onReply(item, account)}
-                            onStatusClick={onStatusClick}
-                            onToggleFavourite={handleToggleFavourite}
+                             onReply={(item) => onReply(item, account)}
+                             onStatusClick={(status) => onStatusClick(status, account)}
+                             onToggleFavourite={handleToggleFavourite}
                             onToggleReblog={handleToggleReblog}
                             onDelete={handleDeleteStatus}
                             activeHandle={
@@ -695,9 +696,9 @@ const TimelineSection = ({
               <TimelineItem
                 key={status.id}
                 status={status}
-                onReply={(item) => onReply(item, account)}
-                onStatusClick={onStatusClick}
-                onToggleFavourite={handleToggleFavourite}
+                 onReply={(item) => onReply(item, account)}
+                 onStatusClick={(status) => onStatusClick(status, account)}
+                 onToggleFavourite={handleToggleFavourite}
                 onToggleReblog={handleToggleReblog}
                 onDelete={handleDeleteStatus}
                 activeHandle={
@@ -1200,8 +1201,10 @@ export const App = () => {
     setSelectedStatus(null);
   };
 
-  const handleStatusClick = (status: Status) => {
+  const handleStatusClick = (status: Status, columnAccount: Account | null) => {
     setSelectedStatus(status);
+    // Status에 columnAccount 정보를 임시 저장
+    (status as any).__columnAccount = columnAccount;
   };
 
   const handleCloseStatusModal = () => {
@@ -1437,7 +1440,8 @@ onAccountChange={setSectionAccount}
                            onAddSectionRight={(id) => addSectionNear(id, "right")}
                            onRemoveSection={removeSection}
                            onReply={handleReply}
-                           onStatusClick={handleStatusClick}
+                            onStatusClick={handleStatusClick}
+                           columnAccount={sectionAccount}
                            onCloseStatusModal={handleCloseStatusModal}
                            onError={(message) => setActionError(message || null)}
                           onMoveSection={moveSection}
@@ -1671,6 +1675,7 @@ onAccountChange={setSectionAccount}
         <StatusModal
           status={selectedStatus}
           account={composeAccount}
+          threadAccount={(selectedStatus as any).__columnAccount || null}
           api={services.api}
           onClose={handleCloseStatusModal}
           onReply={(status) => {

--- a/src/ui/components/StatusModal.tsx
+++ b/src/ui/components/StatusModal.tsx
@@ -6,6 +6,7 @@ import boostIconUrl from "../assets/boost-icon.svg";
 export const StatusModal = ({
   status,
   account,
+  threadAccount,
   api,
   onClose,
   onReply,
@@ -21,6 +22,7 @@ export const StatusModal = ({
 }: {
   status: Status;
   account: Account | null;
+  threadAccount: Account | null;
   api: any; // UnifiedApiClient
   onClose: () => void;
   onReply: (status: Status) => void;
@@ -51,7 +53,9 @@ export const StatusModal = ({
       setThreadError(null);
       
       try {
-        const context = await api.fetchThreadContext(account, displayStatus.id);
+        // 스레드를 가져올 때는 해당 게시글이 속한 컬럼의 계정 사용
+        const targetAccount = threadAccount || account;
+        const context = await api.fetchThreadContext(targetAccount, displayStatus.id);
         setThreadContext(context);
       } catch (error) {
         console.error("스레드 컨텍스트 로딩 실패:", error);


### PR DESCRIPTION
## Summary
- 스레드 API 호출 시 해당 게시글이 속한 컬럼의 계정 정보를 사용하도록 수정
- Misskey에서 "NO_SUCH_NOTE" 에러가 발생하는 문제 해결

## Problem
기존에는 StatusModal에서 스레드 API를 호출할 때 작성 상자에 선택된 계정(`composeAccount`)을 사용했습니다. 이로 인해 다른 계정의 타임라인에서 게시글을 열 때, 해당 게시글이 속한 인스턴스의 계정 정보가 아닌 다른 계정 정보로 API를 호출하여 Misskey에서 "NO_SUCH_NOTE" 에러가 발생했습니다.

## Solution
- `TimelineItem`에서 `onStatusClick` 호출 시 해당 컬럼의 `account` 정보를 함께 전달
- `handleStatusClick`에서 `status` 객체에 컬럼 계정 정보를 임시 저장
- `StatusModal`에 `threadAccount` prop 추가하여 올바른 계정 정보로 API 호출
- `fetchThreadContext` 호출 시 `threadAccount || account` 순서로 올바른 계정 사용

## Testing
- 로컬 환경에서 동작 확인
- Misskey/Mastodon 플랫폼 모두에서 스레드 정상 로드 확인
- 기존 기능과의 호환성 유지 확인