### PR TITLE
원본 서버에서 보기 메뉴 추가

### DIFF
--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -972,6 +972,25 @@ button.ghost {
   color: #6b5c4f;
 }
 
+.status-header-main {
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.status-header-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  flex-direction: row;
+}
+
+.status-menu {
+  margin-left: auto;
+}
+
 .status-avatar,
 .status-account {
   cursor: pointer;
@@ -981,6 +1000,11 @@ button.ghost {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.status header .status-header-info {
+  flex-direction: row;
+  gap: 8px;
 }
 
 .custom-emoji {
@@ -1037,9 +1061,29 @@ button.ghost {
   gap: 4px;
 }
 
+.status header .status-header-info {
+  flex-direction: row;
+  align-items: center;
+}
+
+.status-menu-panel {
+  min-width: 180px;
+}
+
+.status-menu .icon-button {
+  width: 32px;
+  height: 32px;
+}
+
 .status header a {
   color: inherit;
   text-decoration: none;
+}
+
+.status-account strong {
+  display: block;
+  line-height: 1.2;
+  max-height: 1.4em;
 }
 
 .time-link {


### PR DESCRIPTION
## 요약
- 게시글 헤더 메뉴에 "원본 서버에서 보기" 액션을 추가했습니다.
- Misskey에서 url/uri가 없는 경우를 대비해 로컬 노트 퍼머링크를 fallback으로 구성했습니다.
- 메뉴 팝오버의 닫힘/레이아웃/사이즈/간격 스타일을 보정했습니다.

## 테스트
- 수동 확인 (로컬 노트/원격 노트에서 메뉴 표시 및 새 탭 열기)
