### PR TITLE
feat: 이미지 팝업에 이전/다음 네비게이션 버튼 추가

### DIFF
--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1343,6 +1343,49 @@ button.ghost {
   z-index: 2;
 }
 
+.image-modal-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.2s;
+}
+
+.image-modal-nav:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.image-modal-nav-prev {
+  left: 12px;
+}
+
+.image-modal-nav-next {
+  right: 12px;
+}
+
+.image-modal-counter {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 6px 14px;
+  border-radius: 16px;
+  font-size: 14px;
+  z-index: 2;
+}
+
 .confirm-modal {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- 이미지가 2개 이상 첨부된 게시글에서 팝업 내 좌우 화살표 버튼으로 이미지 탐색 가능
- 키보드 네비게이션 지원 (← → 화살표로 이동, ESC로 닫기)
- 현재 이미지 위치를 하단에 카운터로 표시 (예: 1 / 3)

## Test plan
- [ ] 이미지 2개 이상 첨부된 게시글에서 이미지 클릭
- [ ] 좌우 버튼으로 이미지 이동 확인
- [ ] 키보드 화살표 키로 이미지 이동 확인
- [ ] ESC 키로 모달 닫기 확인
- [ ] 이미지 1개인 게시글에서는 버튼/카운터 미표시 확인
- [ ] 줌/패닝 기능 정상 동작 확인

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)