### PR TITLE
fix: align thread popup bg in dark mode

### DIFF
--- a/src/ui/styles/themes/dark.css
+++ b/src/ui/styles/themes/dark.css
@@ -33,6 +33,8 @@
     --shadow-timeline-column: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 12px 24px rgba(0, 0, 0, 0.35);
     --color-status-bg: #171512;
     --color-status-border: #302822;
+    --color-thread-bg: var(--color-status-bg);
+    --color-thread-border: var(--color-status-border);
     --color-status-header: #c4b6a6;
     --color-status-meta: #c4b6a6;
     --color-status-time: #c4b6a6;
@@ -492,6 +494,8 @@
   --shadow-timeline-column: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 12px 24px rgba(0, 0, 0, 0.35);
   --color-status-bg: #171512;
   --color-status-border: #302822;
+  --color-thread-bg: var(--color-status-bg);
+  --color-thread-border: var(--color-status-border);
   --color-status-header: #c4b6a6;
   --color-status-meta: #c4b6a6;
   --color-status-time: #c4b6a6;


### PR DESCRIPTION
## 요약
- 다크 모드에서 스레드 글 배경/테두리가 라이트 색으로 보이던 문제를 수정했습니다.
- 스레드 배경/테두리를 다크 모드 상태 배경/테두리에 연동했습니다.

## 관련 이슈
- https://github.com/deholic/deck/issues/100
