### PR TITLE
refactor: 이미지 줌/드래그 로직 useImageZoom 훅으로 추출

### DIFF
--- a/src/ui/hooks/useImageZoom.ts
+++ b/src/ui/hooks/useImageZoom.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type ImageZoomState = {
+  zoom: number;
+  offset: { x: number; y: number };
+  baseSize: { width: number; height: number } | null;
+  isDragging: boolean;
+};
+
+/**
+ * 이미지 확대/축소 및 드래그 이동을 관리하는 커스텀 훅
+ *
+ * @param imageContainerRef - 이미지 컨테이너 요소의 ref
+ * @param imageRef - 이미지 요소의 ref
+ * @returns 이미지 줌 상태 및 이벤트 핸들러들
+ */
+export const useImageZoom = (
+  imageContainerRef: React.RefObject<HTMLDivElement>,
+  imageRef: React.RefObject<HTMLImageElement>
+) => {
+  const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [baseSize, setBaseSize] = useState<{ width: number; height: number } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStateRef = useRef<{
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+  } | null>(null);
+
+  // offset을 이미지 경계 내로 제한
+  const clampOffset = useCallback(
+    (next: { x: number; y: number }, currentZoom: number) => {
+      if (!baseSize || !imageContainerRef.current) {
+        return next;
+      }
+      const container = imageContainerRef.current.getBoundingClientRect();
+      const maxX = Math.max(0, (baseSize.width * currentZoom - container.width) / 2);
+      const maxY = Math.max(0, (baseSize.height * currentZoom - container.height) / 2);
+      return {
+        x: Math.min(maxX, Math.max(-maxX, next.x)),
+        y: Math.min(maxY, Math.max(-maxY, next.y))
+      };
+    },
+    [baseSize, imageContainerRef]
+  );
+
+  // zoom 변경 시 offset 조정
+  useEffect(() => {
+    setOffset((current) => clampOffset(current, zoom));
+  }, [zoom, clampOffset]);
+
+  // 드래그 중 포인터 이동 처리
+  useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+    const handleMove = (event: PointerEvent) => {
+      if (!dragStateRef.current) {
+        return;
+      }
+      const dx = event.clientX - dragStateRef.current.startX;
+      const dy = event.clientY - dragStateRef.current.startY;
+      const next = {
+        x: dragStateRef.current.originX + dx,
+        y: dragStateRef.current.originY + dy
+      };
+      setOffset(clampOffset(next, zoom));
+    };
+    const handleUp = () => {
+      setIsDragging(false);
+      dragStateRef.current = null;
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+    };
+  }, [clampOffset, zoom, isDragging]);
+
+  // 휠 이벤트 핸들러 (줌 조정)
+  const handleWheel = useCallback((event: React.WheelEvent) => {
+    event.preventDefault();
+    const delta = event.deltaY > 0 ? -0.1 : 0.1;
+    setZoom((current) => Math.min(3, Math.max(0.6, current + delta)));
+  }, []);
+
+  // 이미지 로드 완료 시 base 크기 설정
+  const handleImageLoad = useCallback(() => {
+    if (!imageRef.current) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      if (!imageRef.current) {
+        return;
+      }
+      const rect = imageRef.current.getBoundingClientRect();
+      setBaseSize({ width: rect.width, height: rect.height });
+    });
+  }, [imageRef]);
+
+  // 포인터 다운 시 드래그 시작
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      if (event.button !== 0) {
+        return;
+      }
+      event.preventDefault();
+      dragStateRef.current = {
+        startX: event.clientX,
+        startY: event.clientY,
+        originX: offset.x,
+        originY: offset.y
+      };
+      setIsDragging(true);
+    },
+    [offset]
+  );
+
+  // 줌/오프셋 초기화
+  const reset = useCallback(() => {
+    setZoom(1);
+    setOffset({ x: 0, y: 0 });
+    setBaseSize(null);
+    setIsDragging(false);
+    dragStateRef.current = null;
+  }, []);
+
+  return {
+    // 상태
+    zoom,
+    offset,
+    baseSize,
+    isDragging,
+
+    // 핸들러
+    handleWheel,
+    handleImageLoad,
+    handlePointerDown,
+
+    // 유틸리티
+    reset,
+    setZoom
+  };
+};


### PR DESCRIPTION
## Summary
이미지 확대/축소 및 드래그 이동 로직을 재사용 가능한 커스텀 훅(`useImageZoom`)으로 분리했습니다.

## 변경 사항

### 새로운 파일
- **`src/ui/hooks/useImageZoom.ts`** (147줄)
  - 줌 레벨 관리 (0.6x ~ 3x)
  - 오프셋 자동 클램핑 (이미지가 뷰포트 경계를 벗어나지 않도록)
  - 드래그 상태 및 포인터 이벤트 처리
  - 휠 이벤트를 통한 줌 조정
  - `reset()` 함수로 상태 초기화

### 수정된 파일
- **TimelineItem**: 111줄 제거 → 19줄 추가 (순 감소: 92줄)
  - 중복된 `clampOffset`, `useEffect` 블록 제거
  - 이미지 전환 시 `resetImageZoom()` 호출
  - 이벤트 핸들러를 훅에서 제공하는 함수로 교체

- **ComposeBox**: 102줄 제거 → 17줄 추가 (순 감소: 85줄)
  - 동일한 중복 로직 제거
  - 이미지 전환 시 `resetImageZoom()` 호출
  - 이벤트 핸들러 훅 함수로 통합

## 효과
- **총 177줄의 중복 코드 제거**
- 중앙화된 로직으로 유지보수성 향상
- 다른 컴포넌트에서도 재사용 가능

## Test plan
- [ ] TimelineItem에서 이미지 클릭하여 모달 열기
- [ ] 휠로 줌 인/아웃 테스트
- [ ] 드래그로 이미지 이동 테스트
- [ ] 여러 이미지 간 전환 시 줌/오프셋 초기화 확인
- [ ] ComposeBox에서 동일한 테스트 수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)