### PR TITLE
첨부 이미지 추가 버튼 보더 두께 조정

### DIFF
--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1453,7 +1453,7 @@ button.ghost {
 /* 첨부 영역 내의 이미지 추가 버튼 */
 .compose-attachments .file-button.attachment-thumb {
   background: transparent;
-  border: 2px dashed var(--color-attachment-add-border);
+  border: 1px dashed var(--color-attachment-add-border);
   color: var(--color-attachment-add-text);
   flex-shrink: 0;
 }


### PR DESCRIPTION
## 요약
- 첨부 영역 이미지 추가 버튼의 점선 보더 두께를 2px에서 1px로 조정

## 테스트
- 수동 확인 필요 (UI 변경)