### PR TITLE
프로필 팔로우 버튼과 모달 레이어링 추가

### DIFF
--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -116,8 +116,14 @@ export type UserProfile = {
   url: string | null;
   avatarUrl: string | null;
   headerUrl: string | null;
+  locked: boolean;
   bio: string;
   fields: ProfileField[];
+};
+
+export type AccountRelationship = {
+  following: boolean;
+  requested: boolean;
 };
 
 export type ThreadContext = {

--- a/src/infra/MisskeyHttpClient.ts
+++ b/src/infra/MisskeyHttpClient.ts
@@ -1,6 +1,20 @@
-import type { Account, CustomEmoji, Status, ThreadContext, TimelineType, InstanceInfo, UserProfile } from "../domain/types";
+import type {
+  Account,
+  AccountRelationship,
+  CustomEmoji,
+  Status,
+  ThreadContext,
+  TimelineType,
+  InstanceInfo,
+  UserProfile
+} from "../domain/types";
 import type { CreateStatusInput, MastodonApi } from "../services/MastodonApi";
-import { mapMisskeyNotification, mapMisskeyStatusWithInstance, mapMisskeyUserProfile } from "./misskeyMapper";
+import {
+  mapMisskeyNotification,
+  mapMisskeyRelationship,
+  mapMisskeyStatusWithInstance,
+  mapMisskeyUserProfile
+} from "./misskeyMapper";
 
 const normalizeInstanceUrl = (instanceUrl: string): string => instanceUrl.replace(/\/$/, "");
 
@@ -223,6 +237,36 @@ export class MisskeyHttpClient implements MastodonApi {
     }
     const data = (await response.json()) as unknown;
     return mapMisskeyUserProfile(data, account.instanceUrl);
+  }
+
+  async fetchAccountRelationship(account: Account, accountId: string): Promise<AccountRelationship> {
+    const response = await fetch(`${normalizeInstanceUrl(account.instanceUrl)}/api/users/show`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(buildBody(account, { userId: accountId }))
+    });
+    if (!response.ok) {
+      throw new Error("관계 정보를 불러오지 못했습니다.");
+    }
+    const data = (await response.json()) as unknown;
+    return mapMisskeyRelationship(data);
+  }
+
+  async followAccount(account: Account, accountId: string): Promise<AccountRelationship> {
+    await this.postSimple(account, "/api/following/create", { userId: accountId });
+    return this.fetchAccountRelationship(account, accountId);
+  }
+
+  async unfollowAccount(account: Account, accountId: string): Promise<AccountRelationship> {
+    await this.postSimple(account, "/api/following/delete", { userId: accountId });
+    return this.fetchAccountRelationship(account, accountId);
+  }
+
+  async cancelFollowRequest(account: Account, accountId: string): Promise<AccountRelationship> {
+    await this.postSimple(account, "/api/following/requests/cancel", { userId: accountId });
+    return this.fetchAccountRelationship(account, accountId);
   }
 
   async fetchAccountStatuses(

--- a/src/infra/UnifiedApiClient.ts
+++ b/src/infra/UnifiedApiClient.ts
@@ -37,6 +37,22 @@ export class UnifiedApiClient implements MastodonApi {
     return this.getClient(account).fetchAccountProfile(account, accountId);
   }
 
+  fetchAccountRelationship(account: Account, accountId: string) {
+    return this.getClient(account).fetchAccountRelationship(account, accountId);
+  }
+
+  followAccount(account: Account, accountId: string) {
+    return this.getClient(account).followAccount(account, accountId);
+  }
+
+  unfollowAccount(account: Account, accountId: string) {
+    return this.getClient(account).unfollowAccount(account, accountId);
+  }
+
+  cancelFollowRequest(account: Account, accountId: string) {
+    return this.getClient(account).cancelFollowRequest(account, accountId);
+  }
+
   fetchAccountStatuses(account: Account, accountId: string, limit: number, maxId?: string) {
     return this.getClient(account).fetchAccountStatuses(account, accountId, limit, maxId);
   }

--- a/src/infra/mastodonMapper.ts
+++ b/src/infra/mastodonMapper.ts
@@ -1,4 +1,4 @@
-import type { MediaAttachment, ProfileField, Reaction, Status, UserProfile } from "../domain/types";
+import type { AccountRelationship, MediaAttachment, ProfileField, Reaction, Status, UserProfile } from "../domain/types";
 
 const htmlToText = (html: string): string => {
   // Preserve links as "text (url)" format before DOM parsing
@@ -118,6 +118,7 @@ export const mapAccountProfile = (raw: unknown): UserProfile => {
         ? value.header_static
         : null;
   const bio = typeof value.note === "string" ? value.note : "";
+  const locked = Boolean(value.locked ?? false);
   return {
     id,
     name,
@@ -125,8 +126,17 @@ export const mapAccountProfile = (raw: unknown): UserProfile => {
     url,
     avatarUrl,
     headerUrl,
+    locked,
     bio,
     fields: mapProfileFields(value.fields)
+  };
+};
+
+export const mapAccountRelationship = (raw: unknown): AccountRelationship => {
+  const value = raw as Record<string, unknown>;
+  return {
+    following: Boolean(value.following ?? false),
+    requested: Boolean(value.requested ?? false)
   };
 };
 

--- a/src/infra/misskeyMapper.ts
+++ b/src/infra/misskeyMapper.ts
@@ -1,4 +1,14 @@
-import type { CustomEmoji, MediaAttachment, Mention, ProfileField, Reaction, Status, UserProfile, Visibility } from "../domain/types";
+import type {
+  AccountRelationship,
+  CustomEmoji,
+  MediaAttachment,
+  Mention,
+  ProfileField,
+  Reaction,
+  Status,
+  UserProfile,
+  Visibility
+} from "../domain/types";
 
 const mapVisibility = (visibility: string): Visibility => {
   switch (visibility) {
@@ -328,6 +338,7 @@ export const mapMisskeyUserProfile = (
   const avatarUrl = typeof value.avatarUrl === "string" ? value.avatarUrl : null;
   const headerUrl = typeof value.bannerUrl === "string" ? value.bannerUrl : null;
   const bio = typeof value.description === "string" ? value.description : "";
+  const locked = Boolean(value.isLocked ?? value.isPrivate ?? false);
   return {
     id,
     name,
@@ -335,8 +346,17 @@ export const mapMisskeyUserProfile = (
     url,
     avatarUrl,
     headerUrl,
+    locked,
     bio,
     fields: mapProfileFields(value.fields)
+  };
+};
+
+export const mapMisskeyRelationship = (raw: unknown): AccountRelationship => {
+  const value = raw as Record<string, unknown>;
+  return {
+    following: Boolean(value.isFollowing ?? false),
+    requested: Boolean(value.hasPendingFollowRequestFromYou ?? value.hasPendingFollowRequest ?? false)
   };
 };
 

--- a/src/services/MastodonApi.ts
+++ b/src/services/MastodonApi.ts
@@ -1,4 +1,4 @@
-import type { Account, Status, TimelineType, Visibility, InstanceInfo, UserProfile } from "../domain/types";
+import type { Account, AccountRelationship, Status, TimelineType, Visibility, InstanceInfo, UserProfile } from "../domain/types";
 import type { CustomEmoji } from "../domain/types";
 
 export type CreateStatusInput = {
@@ -25,5 +25,9 @@ export interface MastodonApi {
   unreblog(account: Account, statusId: string): Promise<Status>;
   fetchInstanceInfo(account: Account): Promise<InstanceInfo>;
   fetchAccountProfile(account: Account, accountId: string): Promise<UserProfile>;
+  fetchAccountRelationship(account: Account, accountId: string): Promise<AccountRelationship>;
+  followAccount(account: Account, accountId: string): Promise<AccountRelationship>;
+  unfollowAccount(account: Account, accountId: string): Promise<AccountRelationship>;
+  cancelFollowRequest(account: Account, accountId: string): Promise<AccountRelationship>;
   fetchAccountStatuses(account: Account, accountId: string, limit: number, maxId?: string): Promise<Status[]>;
 }

--- a/src/ui/components/StatusModal.tsx
+++ b/src/ui/components/StatusModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import type { Account, Status, ThreadContext } from "../../domain/types";
 import type { MastodonApi } from "../../services/MastodonApi";
 import { TimelineItem } from "./TimelineItem";
@@ -9,11 +9,13 @@ export const StatusModal = ({
   account,
   threadAccount,
   api,
+  zIndex,
   onClose,
   onReply,
   onToggleFavourite,
   onToggleReblog,
   onDelete,
+  onProfileClick,
   activeHandle,
   activeAccountHandle,
   activeAccountUrl,
@@ -25,11 +27,13 @@ export const StatusModal = ({
   account: Account | null;
   threadAccount: Account | null;
   api: MastodonApi;
+  zIndex?: number;
   onClose: () => void;
   onReply: (status: Status) => void;
   onToggleFavourite: (status: Status) => void;
   onToggleReblog: (status: Status) => void;
   onDelete?: (status: Status) => void;
+  onProfileClick?: (status: Status, account: Account | null) => void;
   activeHandle: string;
   activeAccountHandle: string;
   activeAccountUrl: string | null;
@@ -39,6 +43,15 @@ export const StatusModal = ({
 }) => {
   const displayStatus = status.reblog ?? status;
   const boostedBy = status.reblog ? status.boostedBy : null;
+  const handleProfileClick = useCallback(
+    (target: Status) => {
+      if (!onProfileClick) {
+        return;
+      }
+      onProfileClick(target, threadAccount ?? account ?? null);
+    },
+    [account, onProfileClick, threadAccount]
+  );
   
   // 스레드 컨텍스트 상태
   const [threadContext, setThreadContext] = useState<ThreadContext | null>(null);
@@ -75,6 +88,7 @@ export const StatusModal = ({
       role="dialog"
       aria-modal="true"
       aria-label="글 보기"
+      style={zIndex ? { zIndex } : undefined}
     >
       <div className="status-modal-backdrop" onClick={onClose} />
       <div className="status-modal-content">
@@ -113,6 +127,7 @@ export const StatusModal = ({
                     onToggleFavourite={onToggleFavourite}
                     onToggleReblog={onToggleReblog}
                     onDelete={onDelete || (() => {})}
+                    onProfileClick={handleProfileClick}
                     activeHandle={activeHandle}
                     activeAccountHandle={activeAccountHandle}
                     activeAccountUrl={activeAccountUrl}
@@ -142,6 +157,7 @@ export const StatusModal = ({
             onToggleFavourite={onToggleFavourite}
             onToggleReblog={onToggleReblog}
             onDelete={onDelete || (() => {})}
+            onProfileClick={handleProfileClick}
             activeHandle={activeHandle}
             activeAccountHandle={activeAccountHandle}
             activeAccountUrl={activeAccountUrl}
@@ -170,6 +186,7 @@ export const StatusModal = ({
                     onToggleFavourite={onToggleFavourite}
                     onToggleReblog={onToggleReblog}
                     onDelete={onDelete || (() => {})}
+                    onProfileClick={handleProfileClick}
                     activeHandle={activeHandle}
                     activeAccountHandle={activeAccountHandle}
                     activeAccountUrl={activeAccountUrl}

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1654,7 +1654,7 @@ button.ghost {
 .status-modal {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 60;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1818,7 +1818,100 @@ button.ghost {
   padding: 16px 16px 0;
   color: var(--color-status-modal-title);
   width: 100%;
-  transform: translateY(48px);
+  top: 48px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.profile-hero-main {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.profile-hero-actions {
+  display: flex;
+  align-items: flex-end;
+  margin-left: auto;
+}
+
+.follow-action {
+  position: relative;
+}
+
+.profile-follow-button {
+  border: 1px solid transparent;
+  justify-content: flex-start;
+}
+
+.profile-follow-button.is-following,
+.profile-follow-button.is-requested {
+  background: var(--color-secondary-button-bg);
+  color: var(--color-secondary-button-text);
+  border-color: var(--color-secondary-button-border);
+}
+
+.follow-confirm {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 60;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.follow-confirm::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay-backdrop);
+}
+
+.follow-confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+}
+
+.follow-confirm-tooltip {
+  position: relative;
+  z-index: 1;
+  background: var(--color-status-modal-bg);
+  border: 1px solid var(--color-status-modal-border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-status-modal);
+  padding: 12px 14px;
+  width: min(300px, 84vw);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.follow-confirm-tooltip p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-primary);
+}
+
+.follow-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.follow-confirm-actions button {
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.follow-confirm-actions .delete-button {
+  width: auto;
+  height: auto;
+  padding: 6px 12px;
+  color: var(--color-delete-button-text);
 }
 
 .profile-avatar {


### PR DESCRIPTION
﻿## 요약
- 프로필 모달에 팔로우/요청/언팔로우 버튼과 언팔로우 확인 팝업을 추가했습니다.
- 모달 간 표시 순서를 동적으로 z-index로 제어해 나중에 뜨는 팝업이 항상 위로 오도록 했습니다.
- 게시글 팝업에서 프로필 클릭 시 프로필 모달을 열 수 있도록 연결했습니다.

## 변경 사항
- 프로필 관계 조회/팔로우/언팔로우/요청 취소 API를 통합 클라이언트에 추가
- 프로필 모달 UI/상태/낙관적 업데이트/툴팁 동작 구현
- 프로필/게시글 모달 z-index 동적 적용
- 프로필 모달 버튼/툴팁 스타일 조정

## 테스트
- 미실행
