### PR TITLE
풀 핸들 멘션 링크 프로필 모달 열기

### DIFF
--- a/src/ui/utils/linkify.ts
+++ b/src/ui/utils/linkify.ts
@@ -1,9 +1,37 @@
 import React from "react";
 
+export type MentionLink = {
+  id?: string | null;
+  handle: string;
+  url: string | null;
+  displayName?: string;
+};
+
+export type LinkifyOptions = {
+  mentionResolver?: (handle: string) => MentionLink | null;
+  onMentionClick?: (mention: MentionLink) => void;
+};
+
+const mentionPattern =
+  /@[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?=[^\w@]|$)/g;
 const urlPattern =
   /(https?:\/\/[^\s)\]]+|www\.[^\s)\]]+|[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?:\/[^\s)\]]*)?)(?=[^\w@]|$)/g;
+const linkPattern = new RegExp(`${mentionPattern.source}|${urlPattern.source}`, "g");
 
 const normalizeUrl = (url: string): string => (url.match(/^https?:\/\//) ? url : `https://${url}`);
+const normalizeMentionHandle = (handle: string): string => handle.replace(/^@/, "").trim().toLowerCase();
+const buildMentionUrl = (handle: string): string | null => {
+  const normalized = normalizeMentionHandle(handle);
+  if (!normalized.includes("@")) {
+    return null;
+  }
+  const [username, ...rest] = normalized.split("@");
+  const host = rest.join("@");
+  if (!username || !host) {
+    return null;
+  }
+  return `https://${host}/@${username}`;
+};
 
 export const isPlainUrl = (value: string): boolean => {
   const trimmed = value.trim();
@@ -15,30 +43,64 @@ export const isPlainUrl = (value: string): boolean => {
   );
 };
 
-export const renderTextWithLinks = (text: string, keyPrefix: string): React.ReactNode[] => {
+export const renderTextWithLinks = (
+  text: string,
+  keyPrefix: string,
+  options?: LinkifyOptions
+): React.ReactNode[] => {
+  linkPattern.lastIndex = 0;
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
   let key = 0;
-  while ((match = urlPattern.exec(text)) !== null) {
+  while ((match = linkPattern.exec(text)) !== null) {
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
-    const url = match[0];
-    if (url.includes("@")) {
-      parts.push(url);
+    const matched = match[0];
+    if (matched.startsWith("@") && matched.includes("@")) {
+      const normalizedHandle = normalizeMentionHandle(matched);
+      const mention = options?.mentionResolver?.(normalizedHandle) ?? null;
+      const mentionUrl = mention?.url ?? buildMentionUrl(matched);
+      if (mention && options?.onMentionClick) {
+        parts.push(
+          React.createElement(
+            "button",
+            {
+              key: `${keyPrefix}-mention-${key}`,
+              type: "button",
+              className: "text-link",
+              onClick: () => options.onMentionClick?.(mention),
+              "aria-label": `${mention.displayName ?? mention.handle} 프로필 보기`
+            },
+            matched
+          )
+        );
+      } else if (mentionUrl) {
+        parts.push(
+          React.createElement(
+            "a",
+            { key: `${keyPrefix}-mention-${key}`, href: mentionUrl, target: "_blank", rel: "noreferrer" },
+            matched
+          )
+        );
+      } else {
+        parts.push(matched);
+      }
+    } else if (matched.includes("@")) {
+      parts.push(matched);
     } else {
-      const normalizedUrl = normalizeUrl(url);
+      const normalizedUrl = normalizeUrl(matched);
       parts.push(
         React.createElement(
           "a",
           { key: `${keyPrefix}-link-${key}`, href: normalizedUrl, target: "_blank", rel: "noreferrer" },
-          url
+          matched
         )
       );
     }
     key += 1;
-    lastIndex = match.index + url.length;
+    lastIndex = match.index + matched.length;
   }
   if (lastIndex < text.length) {
     parts.push(text.slice(lastIndex));
@@ -48,7 +110,8 @@ export const renderTextWithLinks = (text: string, keyPrefix: string): React.Reac
 
 export const renderTextWithLinksAndLineBreaks = (
   text: string,
-  keyPrefix: string
+  keyPrefix: string,
+  options?: LinkifyOptions
 ): React.ReactNode[] => {
   const lines = text.split(/\r?\n/);
   const nodes: React.ReactNode[] = [];
@@ -56,7 +119,7 @@ export const renderTextWithLinksAndLineBreaks = (
     if (index > 0) {
       nodes.push(React.createElement("br", { key: `${keyPrefix}-br-${index}` }));
     }
-    nodes.push(...renderTextWithLinks(line, `${keyPrefix}-line-${index}`));
+    nodes.push(...renderTextWithLinks(line, `${keyPrefix}-line-${index}`, options));
   });
   return nodes;
 };


### PR DESCRIPTION
## 요약
- 게시글 본문에서 @user@domain 전체 멘션을 링크로 인식합니다.
- 멘션 링크 클릭 시 외부 이동 대신 프로필 모달을 엽니다.

## 변경 사항
- 멘션 파서에 핸들/링크 인식 로직 추가
- 리치 콘텐츠 링크 클릭 시 멘션만 가로채 프로필 모달로 연결

## 테스트
- 미실행