### PR TITLE
Pretendard 폰트 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
@@ -6,10 +6,10 @@
     <link rel="icon" href="/src/ui/assets/textodon-icon-blue.png" type="image/png" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' https: data: blob:; connect-src https: wss:; style-src 'self' 'unsafe-inline'; script-src 'self';"
+      content="default-src 'self'; img-src 'self' https: data: blob:; connect-src https: wss:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net data:; script-src 'self';"
     />
     <meta property="og:title" content="Deck" />
-    <meta property="og:description" content="오픈소스 페디버스 웹 클라이언트" />
+    <meta property="og:description" content="오픈소스 페디버스 클라이언트" />
     <meta property="og:image" content="/src/ui/assets/textodon-icon-blue.png" />
     <meta property="og:type" content="website" />
     <title>Deck</title>

--- a/src/ui/styles/base.css
+++ b/src/ui/styles/base.css
@@ -1,6 +1,8 @@
-﻿:root {
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css");
+
+:root {
   color-scheme: light dark;
-  font-family: system-ui, -apple-system, "Segoe UI", "Noto Sans", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Pretendard", system-ui, -apple-system, "Segoe UI", "Noto Sans", "Helvetica Neue", Arial, sans-serif;
   background: var(--page-background);
   color: var(--color-text-primary);
   --page-background: radial-gradient(circle at top left, #f0efe9, #f9f7f2 60%, #ffffff);


### PR DESCRIPTION
﻿## 요약
- 전체 텍스트 기본 폰트를 Pretendard로 변경
- Pretendard CDN 로딩을 위한 CSP 허용 추가
- 깨진 og:description 메타를 정상 한글 문구로 정리

## 변경 사항
- `src/ui/styles/base.css`
  - Pretendard @import 추가
  - 기본 font-family 갱신
- `index.html`
  - CSP에 jsDelivr/style/font 허용 추가
  - og:description 문구 수정 및 인코딩 정리

## 확인 사항
- [x] 로컬 `bun dev`에서 폰트 적용 확인
