### PR TITLE
fix: 계정 선택 드롭다운 커스텀 이모지 표시

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -974,7 +974,8 @@ export const App = () => {
           displayName: "",
           handle: "",
           url: null,
-          avatarUrl: null
+          avatarUrl: null,
+          emojis: []
         };
         const verified = await services.api.verifyAccount(draft);
         const fullHandle = formatHandle(verified.handle, pending.instanceUrl);
@@ -995,7 +996,8 @@ export const App = () => {
           name: `${displayName} @${fullHandle}`,
           displayName,
           handle: fullHandle,
-          avatarUrl: verified.avatarUrl
+          avatarUrl: verified.avatarUrl,
+          emojis: verified.emojis ?? []
         });
       } catch (err) {
         setActionError(err instanceof Error ? err.message : "OAuth 처리에 실패했습니다.");

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -14,6 +14,7 @@ export type Account = {
   handle: string;
   url: string | null;
   avatarUrl: string | null;
+  emojis: CustomEmoji[];
 };
 
 export type MediaAttachment = {

--- a/src/infra/MastodonHttpClient.ts
+++ b/src/infra/MastodonHttpClient.ts
@@ -48,7 +48,7 @@ const mapCustomEmojis = (data: unknown): CustomEmoji[] => {
 export class MastodonHttpClient implements MastodonApi {
   async verifyAccount(
     account: Account
-  ): Promise<{ accountName: string; handle: string; avatarUrl: string | null }> {
+  ): Promise<{ accountName: string; handle: string; avatarUrl: string | null; emojis: CustomEmoji[] }> {
     const response = await fetch(`${account.instanceUrl}/api/v1/accounts/verify_credentials`, {
       headers: buildHeaders(account)
     });
@@ -59,7 +59,8 @@ export class MastodonHttpClient implements MastodonApi {
     return {
       accountName: String(data.display_name ?? data.username ?? ""),
       handle: String(data.acct ?? ""),
-      avatarUrl: typeof data.avatar === "string" ? data.avatar : null
+      avatarUrl: typeof data.avatar === "string" ? data.avatar : null,
+      emojis: mapCustomEmojis(data.emojis)
     };
   }
 

--- a/src/infra/MisskeyHttpClient.ts
+++ b/src/infra/MisskeyHttpClient.ts
@@ -137,7 +137,7 @@ export class MisskeyHttpClient implements MastodonApi {
 
   async verifyAccount(
     account: Account
-  ): Promise<{ accountName: string; handle: string; avatarUrl: string | null }> {
+  ): Promise<{ accountName: string; handle: string; avatarUrl: string | null; emojis: CustomEmoji[] }> {
     const response = await fetch(`${normalizeInstanceUrl(account.instanceUrl)}/api/i`, {
       method: "POST",
       headers: {
@@ -152,7 +152,8 @@ export class MisskeyHttpClient implements MastodonApi {
     return {
       accountName: String(data.name ?? data.username ?? ""),
       handle: String(data.username ?? ""),
-      avatarUrl: typeof data.avatarUrl === "string" ? data.avatarUrl : null
+      avatarUrl: typeof data.avatarUrl === "string" ? data.avatarUrl : null,
+      emojis: mapMisskeyEmojis(data)
     };
   }
 

--- a/src/infra/UnifiedApiClient.ts
+++ b/src/infra/UnifiedApiClient.ts
@@ -12,7 +12,9 @@ export class UnifiedApiClient implements MastodonApi {
     return account.platform === "misskey" ? this.misskey : this.mastodon;
   }
 
-  verifyAccount(account: Account): Promise<{ accountName: string; handle: string; avatarUrl: string | null }> {
+  verifyAccount(
+    account: Account
+  ): Promise<{ accountName: string; handle: string; avatarUrl: string | null; emojis: CustomEmoji[] }> {
     return this.getClient(account).verifyAccount(account);
   }
 

--- a/src/services/MastodonApi.ts
+++ b/src/services/MastodonApi.ts
@@ -10,7 +10,9 @@ export type CreateStatusInput = {
 };
 
 export interface MastodonApi {
-  verifyAccount(account: Account): Promise<{ accountName: string; handle: string; avatarUrl: string | null }>;
+  verifyAccount(
+    account: Account
+  ): Promise<{ accountName: string; handle: string; avatarUrl: string | null; emojis: CustomEmoji[] }>;
   fetchHomeTimeline(account: Account, limit: number, maxId?: string): Promise<Status[]>;
   fetchTimeline(account: Account, timeline: TimelineType, limit: number, maxId?: string): Promise<Status[]>;
   fetchCustomEmojis(account: Account): Promise<CustomEmoji[]>;

--- a/src/ui/components/AccountManager.tsx
+++ b/src/ui/components/AccountManager.tsx
@@ -74,6 +74,7 @@ export const AccountManager = ({
                 name={account.name}
                 handle={account.handle ? formatHandle(account.handle, account.instanceUrl) : undefined}
                 instanceUrl={account.instanceUrl}
+                customEmojis={account.emojis}
               />
             </button>
             <button type="button" onClick={() => removeAccount(account.id)} className="ghost">

--- a/src/ui/components/AccountSelector.tsx
+++ b/src/ui/components/AccountSelector.tsx
@@ -18,7 +18,7 @@ export const AccountSelector = ({
   variant?: "panel" | "inline";
 }) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDetailsElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
 
   useClickOutside(dropdownRef, dropdownOpen, () => setDropdownOpen(false));
 
@@ -47,6 +47,7 @@ export const AccountSelector = ({
                 name={activeAccount.name}
                 handle={activeAccount.handle ? formatHandle(activeAccount.handle, activeAccount.instanceUrl) : undefined}
                 instanceUrl={activeAccount.instanceUrl}
+                customEmojis={activeAccount.emojis}
               />
             ) : (
               <span className="account-selector-placeholder">계정을 선택하세요.</span>
@@ -76,6 +77,7 @@ export const AccountSelector = ({
                           name={account.name}
                           handle={account.handle ? formatHandle(account.handle, account.instanceUrl) : undefined}
                           instanceUrl={account.instanceUrl}
+                          customEmojis={account.emojis}
                         />
                       </button>
                       <button type="button" onClick={() => removeAccount(account.id)} className="ghost">


### PR DESCRIPTION
## Summary
- 계정 검증 결과에 커스텀 이모지를 포함해 저장
- 계정 라벨에서 커스텀 이모지 렌더링 적용
- 계정 선택 드롭다운/관리 목록에 이모지 반영

## Issue
- https://github.com/deholic/deck/issues/123