### PR TITLE
feat: 댓글/부스트 라벨에서 스레드 팝업 열기

### DIFF
--- a/src/ui/components/TimelineItem.tsx
+++ b/src/ui/components/TimelineItem.tsx
@@ -367,6 +367,19 @@ export const TimelineItem = ({
     },
     [displayStatus, onStatusClick]
   );
+  const handleStatusKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      if (!onStatusClick) {
+        return;
+      }
+      onStatusClick(displayStatus);
+    },
+    [displayStatus, onStatusClick]
+  );
   const visibilityIcon = useMemo(() => {
     switch (displayStatus.visibility) {
       case "public":
@@ -751,13 +764,29 @@ export const TimelineItem = ({
         </div>
       ) : null}
       {boostedLabel ? (
-        <div className="boosted-by">
+        <div
+          className="boosted-by"
+          onClick={handleStatusClick}
+          onKeyDown={handleStatusKeyDown}
+          role={onStatusClick ? "button" : undefined}
+          tabIndex={onStatusClick ? 0 : undefined}
+          aria-label={onStatusClick ? "부스트한 글 스레드 보기" : undefined}
+          data-interactive={onStatusClick ? "true" : undefined}
+        >
           <BoostIcon aria-hidden="true" focusable="false" />
           <span>{boostedLabel}</span>
         </div>
       ) : null}
       {mentionLabel ? (
-        <div className="reply-info">
+        <div
+          className="reply-info"
+          onClick={handleStatusClick}
+          onKeyDown={handleStatusKeyDown}
+          role={onStatusClick ? "button" : undefined}
+          tabIndex={onStatusClick ? 0 : undefined}
+          aria-label={onStatusClick ? "댓글 스레드 보기" : undefined}
+          data-interactive={onStatusClick ? "true" : undefined}
+        >
           <ReplyIcon aria-hidden="true" focusable="false" />
           <span>{mentionLabel}에게 보낸 답글</span>
         </div>


### PR DESCRIPTION
## Summary
- 댓글/부스트 라벨 클릭 시 스레드 팝업을 열 수 있게 연결
- 키보드 접근성을 위한 엔터/스페이스 처리와 aria-label 추가

## Issues
- Closes #124