### PR TITLE
프리뷰 카드 본문 3줄 제한 (#133)

### DIFF
--- a/src/ui/components/TimelineItem.tsx
+++ b/src/ui/components/TimelineItem.tsx
@@ -892,7 +892,9 @@ export const TimelineItem = ({
               ) : null}
               <div className="link-preview-body">
                 <strong>{previewCard.title}</strong>
-                {previewCard.description ? <span>{previewCard.description}</span> : null}
+                {previewCard.description ? (
+                  <span className="link-preview-description">{previewCard.description}</span>
+                ) : null}
                 <span className="link-preview-url">{previewCard.url}</span>
               </div>
             </a>

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1507,6 +1507,13 @@ button.ghost {
   color: var(--color-link-preview-strong);
 }
 
+.link-preview-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .link-preview-url {
   font-size: 12px;
   color: var(--color-link-preview-url);


### PR DESCRIPTION
## 요약
- 프리뷰 카드 본문을 3줄로 제한

## 변경 사항
- 설명 텍스트에 line-clamp 적용

## 관련 이슈
Closes #133