### PR TITLE
알림 팝오버 닫기 버튼 제거 (#127)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -611,16 +611,6 @@ const TimelineSection = ({
               <>
                 <div className="overlay-backdrop" aria-hidden="true" />
                 <div ref={notificationMenuRef} className="notification-popover panel" role="dialog" aria-modal="true" aria-label="알림">
-                  <div className="notification-popover-header">
-                    <button
-                      type="button"
-                      className="settings-close"
-                      onClick={() => setNotificationsOpen(false)}
-                      aria-label="알림 닫기"
-                    >
-                      닫기
-                    </button>
-                  </div>
                   <div className="notification-popover-body" ref={notificationScrollRef}>
                     {notificationsError ? <p className="error">{notificationsError}</p> : null}
                     {notificationItems.length === 0 && !notificationsLoading ? (

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1141,13 +1141,6 @@ button.ghost {
   z-index: 30;
 }
 
-.notification-popover-header {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-}
-
 .notification-popover-body {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 요약
- 알림 팝오버에서 닫기 버튼을 제거

## 변경 사항
- 알림 팝오버 헤더/버튼 제거 및 관련 스타일 정리

## 관련 이슈
Closes #127