### PR TITLE
feat: 글 작성 상자 전송 버튼 개선 (alpha)

### DIFF
--- a/src/ui/components/ComposeBox.tsx
+++ b/src/ui/components/ComposeBox.tsx
@@ -652,7 +652,7 @@ export const ComposeBox = ({
             </button>
             <button
               type="submit"
-              className="icon-button compose-icon-button"
+              className="icon-button compose-icon-button compose-submit-button"
               aria-label="게시"
               disabled={isSubmitting}
             >
@@ -660,6 +660,7 @@ export const ComposeBox = ({
                 <path d="M22 2L11 13" />
                 <path d="M22 2l-7 20-4-9-9-4 20-7z" />
               </svg>
+              <span>전송</span>
             </button>
           </div>
         </div>

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -744,15 +744,32 @@
 }
 
 .compose-icon-button {
-  background: var(--color-secondary-button-bg);
-  color: var(--color-secondary-button-text);
-  border: 1px solid var(--color-secondary-button-border);
+  background: var(--color-action-bg);
+  color: var(--color-action-text);
+  border: 1px solid var(--color-action-bg);
   width: 34px;
   height: 34px;
 }
 
+.compose-icon-button:not(.compose-submit-button) {
+  width: 34px;
+}
+
 .compose-icon-button:disabled {
   opacity: 0.5;
+}
+
+.compose-submit-button {
+  width: auto !important;
+  min-width: 34px;
+  padding: 8px 12px !important;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.compose-submit-button svg {
+  flex-shrink: 0;
 }
 
 .compose-emoji-panel {


### PR DESCRIPTION
- 이모지, CW, 전송 버튼 색상을 다른 버튼과 동일하게 변경
- 전송 버튼에 '전송' 텍스트 추가로 가시성 향상
- 버튼 너비를 동적으로 조정되도록 수정
- 본문 버튼과 동일한 패딩 적용으로 일관된 UI 제공