### PR TITLE
feat: 답글 작성 시 외부 서버 사용자에게 풀 핸들 사용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { useTimeline } from "./ui/hooks/useTimeline";
 import { useClickOutside } from "./ui/hooks/useClickOutside";
 import { useAppContext } from "./ui/state/AppContext";
 import type { AccountsState, AppServices } from "./ui/state/AppContext";
-import { createAccountId, formatHandle, normalizeInstanceUrl } from "./ui/utils/account";
+import { createAccountId, formatHandle, formatReplyHandle, normalizeInstanceUrl } from "./ui/utils/account";
 import { clearPendingOAuth, createOauthState, loadPendingOAuth, loadRegisteredApp, saveRegisteredApp, storePendingOAuth } from "./ui/utils/oauth";
 import { getTimelineLabel, getTimelineOptions, normalizeTimelineType } from "./ui/utils/timeline";
 import { sanitizeHtml } from "./ui/utils/htmlSanitizer";
@@ -1035,7 +1035,7 @@ export const App = () => {
   const dragStateRef = useRef<{ startX: number; scrollLeft: number; pointerId: number } | null>(null);
   const [isBoardDragging, setIsBoardDragging] = useState(false);
   const replySummary = replyTarget
-    ? `@${replyTarget.accountHandle} · ${replyTarget.content.slice(0, 80)}`
+    ? `@${formatReplyHandle(replyTarget.accountHandle, replyTarget.accountUrl, composeAccount?.instanceUrl ?? "")} · ${replyTarget.content.slice(0, 80)}`
     : null;
   const [route, setRoute] = useState<Route>(() => parseRoute());
   const timelineListeners = useRef<Map<string, Set<(status: Status) => void>>>(new Map());
@@ -1493,7 +1493,8 @@ export const App = () => {
     }
     setComposeAccountId(account.id);
     setReplyTarget(status);
-    setMentionSeed(`@${status.accountHandle}`);
+    const formattedHandle = formatReplyHandle(status.accountHandle, status.accountUrl, account.instanceUrl);
+    setMentionSeed(`@${formattedHandle}`);
     setSelectedStatus(null);
   };
 

--- a/src/ui/utils/account.ts
+++ b/src/ui/utils/account.ts
@@ -26,6 +26,40 @@ export const formatHandle = (handle: string, instanceUrl: string): string => {
   }
 };
 
+export const formatReplyHandle = (
+  accountHandle: string,
+  accountUrl: string | null,
+  currentAccountInstanceUrl: string
+): string => {
+  if (!accountHandle) {
+    return "";
+  }
+  
+  // If handle already includes domain, return as-is
+  if (accountHandle.includes("@")) {
+    return accountHandle;
+  }
+  
+  // Try to determine if user is from the same server
+  if (accountUrl) {
+    try {
+      const userHost = new URL(accountUrl).hostname;
+      const currentHost = new URL(currentAccountInstanceUrl).hostname;
+      
+      // If different servers, use full handle
+      if (userHost !== currentHost) {
+        return `${accountHandle}@${userHost}`;
+      }
+    } catch {
+      // If URL parsing fails, fall back to simple handle
+      return accountHandle;
+    }
+  }
+  
+  // Same server or couldn't determine, use simple handle
+  return accountHandle;
+};
+
 export const parseAccountLabel = (
   label: string
 ): { displayName: string; handle: string } | null => {


### PR DESCRIPTION
## Summary
답글 작성 시 자기 서버 사용자가 아닌 경우 풀 핸들(username@domain)을 사용하도록 수정

## Changes
- **formatReplyHandle 유틸리티 함수 추가**: 서버 비교 및 핸들 포맷팅 로직 구현
- **handleReply 함수 수정**: 답글 시 멘션 시드에 서버 비교 후 적절한 핸들 형식 사용
- **replySummary 수정**: 답글 대상 표시에도 서버 비교 후 올바른 핸들 형식 적용

## Behavior
- 같은 서버 사용자: `@username` (기존과 동일)
- 다른 서버 사용자: `@username@domain` (풀 핸들)

## Testing
- TypeScript 빌드 ✅
- 전체 테스트 통과 ✅ (10/10)
- 기존 기능 유지 확인 ✅