### PR TITLE
fix: 이미지 추가 버튼 보더 색상을 input-border와 통일

### DIFF
--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1746,7 +1746,7 @@ button.ghost {
 /* 첨부 영역 내의 이미지 추가 버튼 */
 .compose-attachments .file-button.attachment-thumb {
   background: transparent;
-  border: 1px dashed var(--color-attachment-add-border);
+  border: 1px dashed var(--color-input-border);
   color: var(--color-attachment-add-text);
   flex-shrink: 0;
 }

--- a/src/ui/styles/themes/dark.css
+++ b/src/ui/styles/themes/dark.css
@@ -112,7 +112,7 @@
     --color-compose-input-bg: #151310;
     --color-attachments-bg: #1a1814;
     --color-attachments-border: #3a312a;
-    --color-attachment-add-border: #8fa6cf;
+
     --color-attachment-add-text: #c4b6a6;
     --color-action-bg: #4a6cb6;
     --color-action-text: #edf3ff;
@@ -238,7 +238,7 @@
     --color-compose-input-bg: #1a100f;
     --color-attachments-bg: #2a1b19;
     --color-attachments-border: #3b2624;
-    --color-attachment-add-border: #cf8c8c;
+
     --color-attachment-add-text: #cf8c8c;
     --color-action-bg: #8f2f2f;
     --color-action-text: #fff1f1;
@@ -349,7 +349,7 @@
     --color-compose-input-bg: #181e2a;
     --color-attachments-bg: #212a3a;
     --color-attachments-border: #2e3b50;
-    --color-attachment-add-border: #f0a6c8;
+
     --color-attachment-add-text: #d7ddea;
     --color-action-bg: #7db4f0;
     --color-action-text: #0f1c2a;
@@ -466,7 +466,7 @@
     --color-compose-input-bg: #101010;
     --color-attachments-bg: #181818;
     --color-attachments-border: #3a3a3a;
-    --color-attachment-add-border: #f0f0f0;
+
     --color-attachment-add-text: #d6d6d6;
     --color-action-bg: #e6e6e6;
     --color-action-text: #111111;
@@ -586,7 +586,7 @@
     --color-compose-input-bg: #0a120e;
     --color-attachments-bg: #101c15;
     --color-attachments-border: #1f3a2b;
-    --color-attachment-add-border: #6ce48b;
+
     --color-attachment-add-text: #8cd49a;
     --color-action-bg: #39b56b;
     --color-action-text: #0b140f;

--- a/src/ui/styles/themes/light.css
+++ b/src/ui/styles/themes/light.css
@@ -108,7 +108,7 @@
   --color-compose-input-bg: #fff7f2;
   --color-attachments-bg: #f3e4dc;
   --color-attachments-border: #ead7cc;
-  --color-attachment-add-border: #c9b9a6;
+  
   --color-attachment-add-text: #7b3f3f;
 }
 
@@ -223,7 +223,7 @@
   --color-compose-input-bg: #f7fbff;
   --color-attachments-bg: #e9f2fb;
   --color-attachments-border: #d6e5f2;
-  --color-attachment-add-border: #aeb7c6;
+  
   --color-attachment-add-text: #4a6b86;
 }
 
@@ -338,7 +338,7 @@
   --color-compose-input-bg: #ffffff;
   --color-attachments-bg: #f1f1f1;
   --color-attachments-border: #1d1d1d;
-  --color-attachment-add-border: #9e9e9e;
+  
   --color-attachment-add-text: #2a2a2a;
   --color-delete-button-bg: #c62828;
   --color-delete-button-text: #fff5f5;
@@ -457,7 +457,7 @@
   --color-compose-input-bg: #f6fff6;
   --color-attachments-bg: #e9f5ec;
   --color-attachments-border: #cfe6d5;
-  --color-attachment-add-border: #a8cdb4;
+  
   --color-attachment-add-text: #2f6b46;
   --color-delete-button-bg: #b13b3b;
   --color-delete-button-text: #fff4f4;


### PR DESCRIPTION
## Summary
이미지 추가 버튼의 보더 색상이 너무 눈에 튀어서, 입력 필드와 동일한 색상으로 통일했습니다.

## Changes
- 이미지 추가 버튼의 보더 색상을 `--color-attachment-add-border`에서 `--color-input-border`로 변경
- 모든 테마 파일에서 불필요한 `--color-attachment-add-border` 변수 제거
- Christmas, Sky-Pink, Monochrome, Matcha-Core 테마와 다크 모드 모두 적용

## Files Changed
- `src/ui/styles/components.css`: 보더 색상 변수 변경
- `src/ui/styles/themes/light.css`: 라이트 테마 변수 정리
- `src/ui/styles/themes/dark.css`: 다크 테마 변수 정리