### PR TITLE
Fix: 마스토돈 좋아요 기능 오류 수정

### DIFF
--- a/src/infra/MastodonHttpClient.ts
+++ b/src/infra/MastodonHttpClient.ts
@@ -398,12 +398,12 @@ export class MastodonHttpClient implements MastodonApi {
     }
   }
 
-  async favourite(_account: Account, _statusId: string): Promise<Status> {
-    throw new Error("즐겨찾기는 미스키 계정에서만 사용할 수 있습니다.");
+  async favourite(account: Account, statusId: string): Promise<Status> {
+    return this.postAction(account, statusId, "favourite");
   }
 
-  async unfavourite(_account: Account, _statusId: string): Promise<Status> {
-    throw new Error("즐겨찾기는 미스키 계정에서만 사용할 수 있습니다.");
+  async unfavourite(account: Account, statusId: string): Promise<Status> {
+    return this.postAction(account, statusId, "unfavourite");
   }
 
   async bookmark(account: Account, statusId: string): Promise<Status> {


### PR DESCRIPTION
## Summary
- 마스토돈 계정에서 좋아요 버튼 클릭 시 "즐겨찾기는 미스키 계정에서만 사용할 수 있습니다" 오류가 발생하는 문제 수정
- MastodonHttpClient의 favourite/unfavourite 메서드를 postAction을 통해 정상적인 API 호출로 구현
- 마스토독 계정에서 좋아요 기능이 정상 동작하도록 개선

## 변경 내용
- `src/infra/MastodonHttpClient.ts`: favourite/unfavourite 메서드 수정
  - 에러 던지기 대신 `/api/v1/statuses/:id/favourite` 및 `/api/v1/statuses/:id/unfavourite` API 호출
  - 기존의 postAction 헬퍼 메서드 재사용으로 일관성 유지

## 영향 범위
- 마스토돈 계정 사용자의 좋아요/좋아요 취소 기능
- App.tsx, ProfileModal.tsx, TimelineItem.tsx에서 호출하는 favourite 관련 로직
- 빌드 통과 확인 (타입스크립트, Vite)

## 테스트
- 마스토돈 계정에서 타임라인/알림/프로필 화면의 좋아요 기능 테스트 필요