### PR TITLE
feat: 설정 팝업 스크롤 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1960,7 +1960,8 @@ onAccountChange={setSectionAccount}
                 닫기
               </button>
             </div>
-            <div className="settings-item settings-item-account">
+            <div className="settings-modal-body">
+              <div className="settings-item settings-item-account">
               <div>
                 <strong>계정 관리</strong>
                 <p>계정을 선택하여 재인증하거나 삭제합니다.</p>
@@ -2162,6 +2163,7 @@ onAccountChange={setSectionAccount}
               >
                 모두 삭제
               </button>
+            </div>
             </div>
           </div>
         </div>

--- a/src/ui/styles/base.css
+++ b/src/ui/styles/base.css
@@ -47,6 +47,9 @@
   --color-settings-select-border: #d8d1c7;
   --color-settings-select-text: #1f1b16;
   --color-settings-select-placeholder: #6b5c4f;
+  --color-settings-scrollbar-track: rgba(0, 0, 0, 0.1);
+  --color-settings-scrollbar-thumb: rgba(0, 0, 0, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(0, 0, 0, 0.5);
   --color-action-bg: #3b5fa8;
   --color-action-text: #f2f6ff;
   --color-action-active-bg: #9db6e3;

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -200,10 +200,11 @@
   position: relative;
   z-index: 1;
   width: min(92vw, 520px);
+  height: 80vh;
+  max-height: 600px;
   margin: 10vh auto 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
 }
 
 .settings-modal-header {
@@ -211,6 +212,9 @@
   justify-content: space-between;
   align-items: center;
   gap: 12px;
+  flex-shrink: 0;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--color-settings-item-border);
 }
 
 .settings-modal-header h3 {
@@ -220,6 +224,31 @@
 .settings-close {
   height: 36px;
   padding: 0 12px;
+}
+
+.settings-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 12px 4px 0;
+}
+
+.settings-modal-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.settings-modal-body::-webkit-scrollbar-track {
+  background: var(--color-settings-scrollbar-track);
+  border-radius: 3px;
+}
+
+.settings-modal-body::-webkit-scrollbar-thumb {
+  background: var(--color-settings-scrollbar-thumb);
+  border-radius: 3px;
+}
+
+.settings-modal-body::-webkit-scrollbar-thumb:hover {
+  background: var(--color-settings-scrollbar-thumb-hover);
 }
 
 .settings-item {
@@ -234,6 +263,10 @@
 .settings-item:first-of-type {
   border-top: none;
   padding-top: 0;
+}
+
+.settings-item:last-of-type {
+  margin-bottom: 0;
 }
 
 .settings-item p {

--- a/src/ui/styles/themes/dark.css
+++ b/src/ui/styles/themes/dark.css
@@ -109,6 +109,9 @@
     --color-settings-select-bg: #151310;
     --color-settings-select-border: #3a312a;
     --color-settings-select-text: #f0e7dc;
+    --color-settings-scrollbar-track: rgba(240, 231, 220, 0.1);
+    --color-settings-scrollbar-thumb: rgba(240, 231, 220, 0.3);
+    --color-settings-scrollbar-thumb-hover: rgba(240, 231, 220, 0.5);
     --color-compose-input-bg: #151310;
     --color-attachments-bg: #1a1814;
     --color-attachments-border: #3a312a;
@@ -235,6 +238,9 @@
     --color-settings-select-bg: #1a100f;
     --color-settings-select-border: #3b2624;
     --color-settings-select-text: #f7e7df;
+    --color-settings-scrollbar-track: rgba(247, 231, 223, 0.1);
+    --color-settings-scrollbar-thumb: rgba(247, 231, 223, 0.3);
+    --color-settings-scrollbar-thumb-hover: rgba(247, 231, 223, 0.5);
     --color-compose-input-bg: #1a100f;
     --color-attachments-bg: #2a1b19;
     --color-attachments-border: #3b2624;
@@ -346,6 +352,9 @@
     --color-settings-select-bg: #181e2a;
     --color-settings-select-border: #2e3b50;
     --color-settings-select-text: #eff1f7;
+    --color-settings-scrollbar-track: rgba(239, 241, 247, 0.1);
+    --color-settings-scrollbar-thumb: rgba(239, 241, 247, 0.3);
+    --color-settings-scrollbar-thumb-hover: rgba(239, 241, 247, 0.5);
     --color-compose-input-bg: #181e2a;
     --color-attachments-bg: #212a3a;
     --color-attachments-border: #2e3b50;
@@ -463,6 +472,9 @@
     --color-settings-select-bg: #101010;
     --color-settings-select-border: #3a3a3a;
     --color-settings-select-text: #f0f0f0;
+    --color-settings-scrollbar-track: rgba(240, 240, 240, 0.1);
+    --color-settings-scrollbar-thumb: rgba(240, 240, 240, 0.3);
+    --color-settings-scrollbar-thumb-hover: rgba(240, 240, 240, 0.5);
     --color-compose-input-bg: #101010;
     --color-attachments-bg: #181818;
     --color-attachments-border: #3a3a3a;
@@ -583,6 +595,9 @@
     --color-settings-select-bg: #0a120e;
     --color-settings-select-border: #1f3a2b;
     --color-settings-select-text: #c6f3d0;
+    --color-settings-scrollbar-track: rgba(198, 243, 208, 0.1);
+    --color-settings-scrollbar-thumb: rgba(198, 243, 208, 0.3);
+    --color-settings-scrollbar-thumb-hover: rgba(198, 243, 208, 0.5);
     --color-compose-input-bg: #0a120e;
     --color-attachments-bg: #101c15;
     --color-attachments-border: #1f3a2b;
@@ -856,6 +871,9 @@
   --color-settings-select-bg: #1a100f;
   --color-settings-select-border: #3b2624;
   --color-settings-select-text: #f7e7df;
+  --color-settings-scrollbar-track: rgba(247, 231, 223, 0.1);
+  --color-settings-scrollbar-thumb: rgba(247, 231, 223, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(247, 231, 223, 0.5);
   --color-compose-input-bg: #1a100f;
   --color-attachments-bg: #2a1b19;
   --color-attachments-border: #3b2624;
@@ -967,6 +985,9 @@
   --color-settings-select-bg: #181e2a;
   --color-settings-select-border: #2e3b50;
   --color-settings-select-text: #eff1f7;
+  --color-settings-scrollbar-track: rgba(239, 241, 247, 0.1);
+  --color-settings-scrollbar-thumb: rgba(239, 241, 247, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(239, 241, 247, 0.5);
   --color-compose-input-bg: #181e2a;
   --color-attachments-bg: #212a3a;
   --color-attachments-border: #2e3b50;
@@ -1084,6 +1105,9 @@
   --color-settings-select-bg: #101010;
   --color-settings-select-border: #3a3a3a;
   --color-settings-select-text: #f0f0f0;
+  --color-settings-scrollbar-track: rgba(240, 240, 240, 0.1);
+  --color-settings-scrollbar-thumb: rgba(240, 240, 240, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(240, 240, 240, 0.5);
   --color-compose-input-bg: #101010;
   --color-attachments-bg: #181818;
   --color-attachments-border: #3a3a3a;
@@ -1204,6 +1228,9 @@
   --color-settings-select-bg: #0a120e;
   --color-settings-select-border: #1f3a2b;
   --color-settings-select-text: #c6f3d0;
+  --color-settings-scrollbar-track: rgba(198, 243, 208, 0.1);
+  --color-settings-scrollbar-thumb: rgba(198, 243, 208, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(198, 243, 208, 0.5);
   --color-compose-input-bg: #0a120e;
   --color-attachments-bg: #101c15;
   --color-attachments-border: #1f3a2b;

--- a/src/ui/styles/themes/light.css
+++ b/src/ui/styles/themes/light.css
@@ -105,6 +105,9 @@
   --color-settings-select-bg: #fff7f2;
   --color-settings-select-border: #ead7cc;
   --color-settings-select-text: #5b1f1f;
+  --color-settings-scrollbar-track: rgba(91, 31, 31, 0.1);
+  --color-settings-scrollbar-thumb: rgba(91, 31, 31, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(91, 31, 31, 0.5);
   --color-compose-input-bg: #fff7f2;
   --color-attachments-bg: #f3e4dc;
   --color-attachments-border: #ead7cc;
@@ -220,6 +223,9 @@
   --color-settings-select-bg: #f7fbff;
   --color-settings-select-border: #d6e5f2;
   --color-settings-select-text: #2b4f7d;
+  --color-settings-scrollbar-track: rgba(43, 79, 125, 0.1);
+  --color-settings-scrollbar-thumb: rgba(43, 79, 125, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(43, 79, 125, 0.5);
   --color-compose-input-bg: #f7fbff;
   --color-attachments-bg: #e9f2fb;
   --color-attachments-border: #d6e5f2;
@@ -335,6 +341,9 @@
   --color-settings-select-bg: #ffffff;
   --color-settings-select-border: #1d1d1d;
   --color-settings-select-text: #111111;
+  --color-settings-scrollbar-track: rgba(0, 0, 0, 0.1);
+  --color-settings-scrollbar-thumb: rgba(0, 0, 0, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(0, 0, 0, 0.5);
   --color-compose-input-bg: #ffffff;
   --color-attachments-bg: #f1f1f1;
   --color-attachments-border: #1d1d1d;
@@ -454,6 +463,9 @@
   --color-settings-select-bg: #f6fff6;
   --color-settings-select-border: #cfe6d5;
   --color-settings-select-text: #0f3b22;
+  --color-settings-scrollbar-track: rgba(15, 59, 34, 0.1);
+  --color-settings-scrollbar-thumb: rgba(15, 59, 34, 0.3);
+  --color-settings-scrollbar-thumb-hover: rgba(15, 59, 34, 0.5);
   --color-compose-input-bg: #f6fff6;
   --color-attachments-bg: #e9f5ec;
   --color-attachments-border: #cfe6d5;


### PR DESCRIPTION
## Summary
- 설정 항목이 많아져 스크린 한계를 넘는 문제 해결
- 헤더는 고정하고 설정 항목들만 스크롤 가능하도록 개선

## Changes
- **구조 수정**: settings-modal-body wrapper 추가
- **스타일링**: 헤더 고정, border 추가, 스크롤바 스타일링
- **반응형**: 80vh (max 600px) 높이 적용
- **테마**: 9개 라이트/다크 테마에 스크롤바 색상 변수 추가
- **여백**: 첫 항목 상단 패딩 추가

## Technical Details
- WebKit 스크롤바 커스터마이징으로 깔끔한 UI 유지
- 모든 테마와 색상 모드 호환성 확보
- 접근성 및 모바일 반응형 고려