### PR TITLE
fix: 게시글 본문 텍스트 선택 허용

### DIFF
--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1682,7 +1682,7 @@ button.ghost {
   font-size: 15px;
   line-height: 1.5;
   white-space: pre-wrap;
-  user-select: none;
+  user-select: text;
 }
 
 .rich-content {
@@ -1690,7 +1690,7 @@ button.ghost {
   font-size: 15px;
   line-height: 1.5;
   white-space: pre-wrap;
-  user-select: none;
+  user-select: text;
 }
 
 .status-translation {


### PR DESCRIPTION
## Summary
- 게시글 본문 영역인 `.status-text`, `.rich-content`에서 텍스트 드래그 선택을 다시 허용했습니다.
- 카드 전체의 비텍스트 인터랙션은 유지하려고 `.status`의 선택 차단 규칙은 그대로 뒀습니다.
- 변경 후 `bun run build`로 빌드가 성공하는 것을 확인했습니다.